### PR TITLE
Fix discoverCoreModules() to use DIRECTORY_SEPARATOR instead '/'

### DIFF
--- a/bonfire/Bonfire.php
+++ b/bonfire/Bonfire.php
@@ -92,11 +92,11 @@ class Bonfire
             $map = directory_map(ROOTPATH . 'bonfire/Modules', 1);
 
             foreach ($map as $row) {
-                if (substr($row, -1) !== '/') {
+                if (substr($row, -1) !== DIRECTORY_SEPARATOR) {
                     continue;
                 }
 
-                $name = trim($row, '/');
+                $name = trim($row, DIRECTORY_SEPARATOR);
                 $modules["Bonfire\\Modules\\{$name}"] = ROOTPATH . "bonfire/Modules/{$name}";
             }
 


### PR DESCRIPTION
In windows system it do not work unless it use the DIRECTORY_SEPARATOR constant