### PR TITLE
feat(component-renderer): look for components in default paths as fallback

### DIFF
--- a/app/Config/Bonfire.php
+++ b/app/Config/Bonfire.php
@@ -9,18 +9,4 @@ class Bonfire extends BaseConfig
     public $views = [
         'filter_list' => 'Bonfire\Views\_filter_list',
     ];
-
-    /**
-     * --------------------------------------------------------------------------
-     * Components' default lookup paths
-     * --------------------------------------------------------------------------
-     *
-     * The list of paths to look for a component as a fallback (by order of priority).
-     * Useful when having a components library to be used across multiple themes.
-     * 
-     * NB: paths MUST end with a slash (/)
-     */
-    public $componentsLookupPaths = [
-        APPPATH . 'Views/Components/'
-    ];
 }

--- a/app/Config/Bonfire.php
+++ b/app/Config/Bonfire.php
@@ -9,4 +9,18 @@ class Bonfire extends BaseConfig
     public $views = [
         'filter_list' => 'Bonfire\Views\_filter_list',
     ];
+
+    /**
+     * --------------------------------------------------------------------------
+     * Components' default lookup paths
+     * --------------------------------------------------------------------------
+     *
+     * The list of paths to look for a component as a fallback (by order of priority).
+     * Useful when having a components library to be used across multiple themes.
+     * 
+     * NB: paths MUST end with a slash (/)
+     */
+    public $componentsLookupPaths = [
+        APPPATH . 'Views/Components/'
+    ];
 }

--- a/app/Config/Themes.php
+++ b/app/Config/Themes.php
@@ -31,4 +31,19 @@ class Themes
      * @var bool
      */
     public $haveComponents = true;
+
+
+    /**
+     * --------------------------------------------------------------------------
+     * Components' default lookup paths
+     * --------------------------------------------------------------------------
+     *
+     * The list of paths to look for a component as a fallback (by order of priority).
+     * Useful when having a components library to be used across multiple themes.
+     * 
+     * NB: paths MUST end with a slash (/)
+     */
+    public $componentsLookupPaths = [
+        APPPATH . 'Views/Components/'
+    ];
 }

--- a/bonfire/View/ComponentRenderer.php
+++ b/bonfire/View/ComponentRenderer.php
@@ -234,7 +234,7 @@ class ComponentRenderer
         }
 
         // fallback: check in components' default lookup paths from config
-        $componentsLookupPaths = config('Bonfire')->componentsLookupPaths;
+        $componentsLookupPaths = config('Themes')->componentsLookupPaths;
         foreach ($componentsLookupPaths as $componentPath) {
             $filePath = $componentPath . $name . '.php';
 

--- a/bonfire/View/ComponentRenderer.php
+++ b/bonfire/View/ComponentRenderer.php
@@ -233,6 +233,13 @@ class ComponentRenderer
             return $filePath;
         }
 
+        // check in app path
+        $filePath = APPPATH . 'Views/Components/' . $name . '.php';
+
+        if (is_file($filePath)) {
+            return $filePath;
+        }
+
         throw new \RuntimeException('View not found for component: '. $name);
         // @todo look in all normal namespaces
     }

--- a/bonfire/View/ComponentRenderer.php
+++ b/bonfire/View/ComponentRenderer.php
@@ -233,11 +233,14 @@ class ComponentRenderer
             return $filePath;
         }
 
-        // check in app path
-        $filePath = APPPATH . 'Views/Components/' . $name . '.php';
+        // fallback: check in components' default lookup paths from config
+        $componentsLookupPaths = config('Bonfire')->componentsLookupPaths;
+        foreach ($componentsLookupPaths as $componentPath) {
+            $filePath = $componentPath . $name . '.php';
 
-        if (is_file($filePath)) {
-            return $filePath;
+            if (is_file($filePath)) {
+                return $filePath;
+            }
         }
 
         throw new \RuntimeException('View not found for component: '. $name);


### PR DESCRIPTION
Hey @lonnieezell, I've made a not so interesting change in order to create the PR for discussion.

After the comment I've made (https://github.com/lonnieezell/Bonfire2/issues/5#issuecomment-908423807), I now realize that the structure of Bonfire2 is quite different from what I have, so I'd like to know what you are thinking about when locating view components.

If I understand correctly, in Bonfire2, each view in a theme can access the local components in the theme folder. And it would be nice to have a way to access common base components like buttons, links, form elements, or whatever to use across themes? So, one way would be to consider the default views folder a good place to put them, or even a Components folder directly in the default app path or themes path? Or another way would be to add a Components config file where we would add other discovery paths?

Also, I'm thinking maybe we would want to share common components to multiple themes but not all. For instance, Admin and Auth themes would have the same base components that the App would not need/share. So maybe the configuration should be done in the Theme class?

One more thing, when locating components, the Theme class is called to get the path, creating a coupling that may not be ideal for the future view components library.

I don't use themes for my project yet, I have a ViewComponents config file where I put the paths to look in. Then, I compare them with the current view path when locating the Components.

Anyways, sorry for the long comment, still trying to figure things out 😅