### PR TITLE
Fix env text replace

### DIFF
--- a/bonfire/Commands/Install.php
+++ b/bonfire/Commands/Install.php
@@ -129,7 +129,7 @@ class Install extends BaseCommand
         $this->updateEnvFile('# database.default.username = root', "database.default.username = {$user}");
         $this->updateEnvFile('# database.default.password = root', "database.default.password = {$pass}");
         $this->updateEnvFile('# database.default.DBDriver = MySQLi', "database.default.DBDriver = {$driver}");
-        $this->updateEnvFile('# database.default.DBPrefix = ', "database.default.DBPrefix = {$prefix}");
+        $this->updateEnvFile('# database.default.DBPrefix =', "database.default.DBPrefix = {$prefix}");
     }
 
     private function migrate()


### PR DESCRIPTION
DBPrefix are not affected by change during installation because `# database.default.DBPrefix =` in env file doesn't contain space after `=`