### PR TITLE
Update Toolkit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: composer
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
   open-pull-requests-limit: 10
 
 - package-ecosystem: "github-actions"

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Create PHPStan cache directory
@@ -71,11 +71,11 @@ jobs:
 
       - name: Install dependencies (limited)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Install dependencies (authenticated)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 

--- a/.github/workflows/deduplicate.yml
+++ b/.github/workflows/deduplicate.yml
@@ -10,7 +10,7 @@ on:
       - 'app/**'
       - 'bonfire/**'
       - 'tests/**'
-      - '.github/workflows/test-phpcpd.yml'
+      - '.github/workflows/deduplicate.yml'
   push:
     branches:
       - 'develop'
@@ -18,7 +18,7 @@ on:
       - 'app/**'
       - 'bonfire/**'
       - 'tests/**'
-      - '.github/workflows/test-phpcpd.yml'
+      - '.github/workflows/deduplicate.yml'
 
 jobs:
   build:
@@ -32,10 +32,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-          tools: phive
-          extensions: intl, json, mbstring, xml
+          tools: phpcpd
+          extensions: dom, mbstring
 
       - name: Detect code duplication
-        run: |
-            sudo phive --no-progress install --global --trust-gpg-keys 4AA394086372C20A phpcpd
-            phpcpd src/ tests/
+        run: phpcpd app/ src/ tests/

--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Create Deptrac cache directory
@@ -67,15 +67,15 @@ jobs:
 
       - name: Install dependencies (limited)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Install dependencies (authenticated)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Run architectural inspection
         run: |
-            sudo phive --no-progress install --global --trust-gpg-keys B8F640134AB1782E,A98E898BB53EB748 qossmic/deptrac
-            deptrac analyze --cache-file=build/deptrac.cache
+          sudo phive --no-progress install --global --trust-gpg-keys B8F640134AB1782E,A98E898BB53EB748 qossmic/deptrac
+          deptrac analyze --cache-file=build/deptrac.cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,16 +42,16 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies (limited)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Install dependencies (authenticated)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,13 +62,12 @@ writable/uploads/*
 
 writable/debugbar/*
 
-php_errors.log
-
 #-------------------------
 # Public Uploads
 #-------------------------
 
 public/uploads/*
+public/error_log
 
 #-------------------------
 # User Guide Temp Files
@@ -82,6 +81,11 @@ user_guide_src/cilexer/pycilexer.egg-info/*
 # Test Files
 #-------------------------
 tests/coverage*
+phpunit*.xml
+phpunit
+.phpunit*.cache
+php_errors.log
+build/
 
 # Don't save phpunit under version control.
 phpunit
@@ -107,7 +111,6 @@ _modules/*
 
 # Netbeans
 nbproject/
-build/
 nbbuild/
 dist/
 nbdist/

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,16 @@
 	"name": "lonnieezell/bonfire",
 	"type": "project",
 	"description": "A project skeleton/admin area for CodeIgniter 4 projects",
+	"keywords": [
+		"codeigniter",
+		"codeigniter4"
+	],
+	"homepage": "https://github.com/lonnieezell/Bonfire2",
 	"license": "MIT",
 	"require": {
-		"php": "^7.4||^8.0",
+		"php": "^7.4 || ^8.0",
 		"ext-json": "*",
-		"codeigniter4/framework": "^4",
+		"codeigniter4/framework": "^4.0",
 		"tatter/alerts": "^2.1",
 		"lonnieezell/codigniter-shield": "dev-develop",
 		"components/font-awesome": "^5.15",
@@ -22,9 +27,6 @@
 		"nexusphp/tachycardia": "^1.0",
 		"phpstan/phpstan": "^1.1"
 	},
-	"suggest": {
-		"ext-fileinfo": "Improves mime type detection for files"
-	},
 	"autoload": {
 		"psr-4": {
 			"App\\": "app",
@@ -36,17 +38,13 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
+			"Bonfire\\": "bonfire",
 			"Tests\\": "tests",
-			"Tests\\Support\\": "tests/_support",
-			"Bonfire\\": "bonfire"
+			"Tests\\Support\\": "tests/_support"
 		}
 	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/lonnieezell/codigniter-shield"
-		}
-	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"scripts": {
 		"analyze": "phpstan analyze",
 		"ci": [
@@ -59,9 +57,17 @@
 		],
 		"deduplicate": "phpcpd app/ bonfire/",
 		"inspect": "deptrac analyze --cache-file=build/deptrac.cache",
-		"mutate": "infection --threads=2 --skip-initial-tests --coverage=build/phpunit",
 		"style": "php-cs-fixer fix --verbose --ansi --using-cache=no",
 		"test": "phpunit"
+	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/lonnieezell/codigniter-shield"
+		}
+	],
+	"suggest": {
+		"ext-fileinfo": "Improves mime type detection for files"
 	},
 	"support": {
 		"forum": "http://forum.codeigniter.com/",

--- a/depfile.yaml
+++ b/depfile.yaml
@@ -45,7 +45,7 @@ layers:
       - type: bool
         must:
         - type: directory
-          regex: src/Config/.*
+          regex: app/Config/.*
         must_not:
         - type: className
           regex: .*Services
@@ -65,7 +65,7 @@ layers:
       - type: bool
         must:
         - type: directory
-          regex: src/Entities/.*
+          regex: app/Entities/.*
         must_not:
         - type: directory
           regex: vendor/.*
@@ -80,7 +80,7 @@ layers:
       - type: bool
         must:
         - type: directory
-          regex: src/Views/.*
+          regex: app/Views/.*
         must_not:
         - type: directory
           regex: vendor/.*
@@ -110,6 +110,7 @@ ruleset:
     - Entity
     - Service
     - Vendor Config
+    - Vendor Entity
     - Vendor Model
   Service:
     - Config

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,7 @@ parameters:
 		- tests
 	bootstrapFiles:
 		- vendor/codeigniter4/framework/system/Test/bootstrap.php
-	excludes_analyse:
+	excludePaths:
 		- **/Routes.php
 		- **/Views/*
 	ignoreErrors:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,51 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 		bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
 		backupGlobals="false"
+		beStrictAboutCoversAnnotation="true"
+		beStrictAboutOutputDuringTests="true"
+		beStrictAboutTodoAnnotatedTests="true"
 		colors="true"
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
+		executionOrder="random"
+		failOnRisky="true"
+		failOnWarning="true"
 		stopOnError="false"
 		stopOnFailure="false"
 		stopOnIncomplete="false"
 		stopOnSkipped="false"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+		verbose="true">
+
 	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
 		<include>
 			<directory suffix=".php">./app</directory>
+			<directory suffix=".php">./bonfire</directory>
 		</include>
 		<exclude>
+			<directory suffix=".php">./app/Config</directory>
 			<directory suffix=".php">./app/Views</directory>
+			<directory suffix=".php">./bonfire/Views</directory>
 			<file>./app/Config/Routes.php</file>
 		</exclude>
 		<report>
-			<clover outputFile="build/logs/clover.xml"/>
-			<html outputDirectory="build/logs/html"/>
-			<php outputFile="build/logs/coverage.serialized"/>
+			<clover outputFile="build/phpunit/clover.xml"/>
+			<html outputDirectory="build/phpunit/html"/>
+			<php outputFile="build/phpunit/coverage.serialized"/>
 			<text outputFile="php://stdout" showUncoveredFiles="false"/>
+			<xml outputDirectory="build/phpunit/xml-coverage"/>
 		</report>
 	</coverage>
+
 	<testsuites>
-		<testsuite name="App">
+		<testsuite name="app">
 			<directory>./tests</directory>
 		</testsuite>
 	</testsuites>
+
+	<extensions>
+		<extension class="Nexus\PHPUnit\Extension\Tachycardia">
+			<arguments>
+				<array>
+					<element key="timeLimit">
+						<double>0.50</double>
+					</element>
+					<element key="reportable">
+						<integer>30</integer>
+					</element>
+					<element key="precision">
+						<integer>2</integer>
+					</element>
+					<element key="collectBare">
+						<boolean>true</boolean>
+					</element>
+					<element key="tabulate">
+						<boolean>true</boolean>
+					</element>
+				</array>
+			</arguments>
+		</extension>
+	</extensions>
+
 	<logging>
-		<testdoxHtml outputFile="build/logs/testdox.html"/>
-		<testdoxText outputFile="build/logs/testdox.txt"/>
-		<junit outputFile="build/logs/logfile.xml"/>
+		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
+		<testdoxText outputFile="build/phpunit/testdox.txt"/>
+		<junit outputFile="build/phpunit/junit.xml"/>
 	</logging>
+
 	<php>
-		<server name="app.baseURL" value="http://example.com/"/>
+		<env name="XDEBUG_MODE" value="coverage"/>
+		<server name="app.baseURL" value="http://example.com"/>
+
 		<!-- Directory containing phpunit.xml -->
 		<const name="HOMEPATH" value="./"/>
+
 		<!-- Directory containing the Paths config file -->
 		<const name="CONFIGPATH" value="./app/Config/"/>
+
 		<!-- Directory containing the front controller (index.php) -->
 		<const name="PUBLICPATH" value="./public/"/>
+
+		<!-- https://getcomposer.org/xdebug -->
+		<env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
+
 		<!-- Database configuration -->
-		<!-- Uncomment to provide your own database for testing
+		<env name="database.tests.strictOn" value="true"/>
+		<!-- Uncomment to use alternate testing database configuration
 		<env name="database.tests.hostname" value="localhost"/>
 		<env name="database.tests.database" value="tests"/>
 		<env name="database.tests.username" value="tests_user"/>


### PR DESCRIPTION
Fixes a number of issues with the CI/CD files
* Since Bonfire represents a project all source code references should be in **app/** and **bonfire/**, not **src/**
* Projects with **composer.lock** file need to use `composer install` to maintain versioning, and the lock file should eb used when cache hashing
* Updated PHPUnit's config for more thorough testing and to include **bonfire/* in coverage results
* Numerous tweaks to configuration files related to CI/CD