### PR TITLE
Fix Deptrac

### DIFF
--- a/app/Config/Recycler.php
+++ b/app/Config/Recycler.php
@@ -2,7 +2,6 @@
 
 namespace Config;
 
-use App\Models\UserModel;
 use Bonfire\Recycler\Config\Recycler as BaseRecycler;
 
 class Recycler extends BaseRecycler
@@ -30,7 +29,7 @@ class Recycler extends BaseRecycler
     public $resources = [
         'users' => [
             'label'   => 'Users',
-            'model'   => UserModel::class,
+            'model'   => 'App\Models\UserModel',
             'columns' => [
                 'username', 'first_name', 'last_name', 'email',
             ],

--- a/bonfire/Modules/Recycler/Config/Recycler.php
+++ b/bonfire/Modules/Recycler/Config/Recycler.php
@@ -11,7 +11,6 @@
 
 namespace Bonfire\Recycler\Config;
 
-use App\Models\UserModel;
 use CodeIgniter\Config\BaseConfig;
 
 class Recycler extends BaseConfig
@@ -39,7 +38,7 @@ class Recycler extends BaseConfig
     public $resources = [
         'users' => [
             'label'   => 'Users',
-            'model'   => UserModel::class,
+            'model'   => 'App\Models\UserModel',
             'columns' => [
                 'username', 'first_name', 'last_name', 'email',
             ],


### PR DESCRIPTION
Using the class import indicates to Deptrac that the class is a dependency. In this case the config files are just using the import for the class name, so I moved them to simple strings.