### PR TITLE
wrong driver name for SQLite leads to exception being thrown

### DIFF
--- a/bonfire/Commands/Install.php
+++ b/bonfire/Commands/Install.php
@@ -138,7 +138,7 @@ class Install extends BaseCommand
         $name   = CLI::prompt('Database name:', 'bonfire');
         $user   = CLI::prompt('Database username:', 'root');
         $pass   = CLI::prompt('Database password:', 'root');
-        $driver = CLI::prompt('Database driver:', ['MySQLi', 'Postgre', 'SQLite']);
+        $driver = CLI::prompt('Database driver:', ['MySQLi', 'Postgre', 'SQLite3']);
         $prefix = CLI::prompt('Table prefix:');
 
         $this->updateEnvFile('# database.default.hostname = localhost', "database.default.hostname = {$host}");


### PR DESCRIPTION
Driver name is incorrect, leading to exception when trying to either create the database or finish installation:

jstoner@pulsar:~/Development/jeffstoner/fred$ php spark bf:install

CodeIgniter v4.1.8 Command Line Tool - Server Time: 2022-02-02 14:17:44 UTC-06:00

Creating .env file...Done
Setting initial environment

What URL are you running Bonfire under locally? : localhost
Database host:  [localhost]: 
Database name:  [bonfire]: bonfire.db
Database username:  [root]: 
Database password:  [root]: 
Database driver: [MySQLi, Postgre, SQLite]: SQLite
Table prefix: : 

If you need to create your database, you may run:
	php spark db:create <database name>

To migrate and create the initial user, please run: 
	php spark bf:install --continue


jstoner@pulsar:~/Development/jeffstoner/fred$ php spark db:create

CodeIgniter v4.1.8 Command Line Tool - Server Time: 2022-02-02 14:18:56 UTC-06:00


[Error]

Class 'CodeIgniter\Database\SQLite\Connection' not found

at SYSTEMPATH/Database/Database.php:136

Backtrace:
  1    SYSTEMPATH/Database/Database.php:56
       CodeIgniter\Database\Database()->initDriver()

  2    SYSTEMPATH/Database/Config.php:78
       CodeIgniter\Database\Database()->load()

  3    SYSTEMPATH/Model.php:97
       CodeIgniter\Database\Config::connect()

  4    VENDORPATH/lonnieezell/codigniter-shield/src/Auth.php:162
       CodeIgniter\Model()->__construct()

  5    VENDORPATH/lonnieezell/codigniter-shield/src/Auth.php:39
       Sparks\Shield\Auth()->getProvider()

  6    VENDORPATH/lonnieezell/codigniter-shield/src/Config/Services.php:25
       Sparks\Shield\Auth()->__construct()

  7    SYSTEMPATH/Config/BaseService.php:248
       Sparks\Shield\Config\Services::auth()

  8    SYSTEMPATH/Config/BaseService.php:189
       CodeIgniter\Config\BaseService::__callStatic()

  9    VENDORPATH/lonnieezell/codigniter-shield/src/Config/Services.php:20
       CodeIgniter\Config\BaseService::getSharedInstance()

 10    SYSTEMPATH/Config/BaseService.php:248
       Sparks\Shield\Config\Services::auth()

 11    SYSTEMPATH/Common.php:929
       CodeIgniter\Config\BaseService::__callStatic()

 12    APPPATH/Config/Routes.php:38
       service()

 13    SYSTEMPATH/CodeIgniter.php:706
       require('/home/jstoner/Development/jeffstoner/fred/app/Config/Routes.php')

 14    SYSTEMPATH/CodeIgniter.php:361
       CodeIgniter\CodeIgniter()->tryToRouteIt()

 15    SYSTEMPATH/CodeIgniter.php:320
       CodeIgniter\CodeIgniter()->handleRequest()

 16    SYSTEMPATH/CLI/Console.php:48
       CodeIgniter\CodeIgniter()->run()

 17    ROOTPATH/spark:63
       CodeIgniter\CLI\Console()->run()
