### PR TITLE
chore: fix phpunit.xml coverage.exclude

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,7 @@
 		</include>
 		<exclude>
 			<directory suffix=".php">./src/Views</directory>
-			<directory suffix=".php">./src/Consent/Views</directory>
+			<directory suffix=".php">./src/*/Views</directory>
 		</exclude>
 		<report>
 			<clover outputFile="build/phpunit/clover.xml"/>


### PR DESCRIPTION
Fix the following error:
```
Generating code coverage report in Clover XML format ... Call to undefined method SebastianBergmann\CodeCoverage\CodeCoverage::extend()
Error: Process completed with exit code 2.
```
https://github.com/lonnieezell/Bonfire2/actions/runs/3798657461/jobs/6460512391