### PR TITLE
Labels and one missing error message for user fields validation

### DIFF
--- a/src/Users/Config/Users.php
+++ b/src/Users/Config/Users.php
@@ -56,10 +56,22 @@ class Users extends BaseConfig
      * Validation rules used when saving a user.
      */
     public $validation = [
-        'email'      => 'required|valid_email|unique_email[{id}]',
-        'username'   => 'required|string|is_unique[users.username,id,{id}]',
-        'first_name' => 'permit_empty|string|min_length[3]',
-        'last_name'  => 'permit_empty|string|min_length[3]',
+        'email'      => [
+            'label' => 'Email',
+            'rules' => 'required|valid_email|unique_email[{id}]',
+            'errors'=> [
+                'unique_email' => 'This email is already in use. Could belong to a current or a deleted user.',
+            ],
+        ],
+        'username'   => [
+            'label' => 'Username', 'rules' => 'required|string|is_unique[users.username,id,{id}]',
+        ],
+        'first_name' => [
+            'label' => 'First Name', 'rules' => 'permit_empty|string|min_length[3]',
+        ],
+        'last_name'  => [
+            'label' => 'Last Name', 'rules' => 'permit_empty|string|min_length[3]',
+        ],
     ];
 
     /**


### PR DESCRIPTION
Perhaps the fix could further be improved by reverting to default CI validation for unique fields for email, like this: 
```
        'email'      => [
            'label' => 'Email',
            'rules' => 'required|valid_email|is_unique[auth_identities.secret,user_id,{id}]',
        ],
```

This would also allow to do away with the custom Validation file: 
src/Users/Validation/UserRules.php 

which contains the rule unique_email

What do you think?

Another question: would it be ok to use config file __constructor to define labels as translatable strings, or would another solution be in order (like using registrars)?