### PR TITLE
VSCode  Suggestions & DocBlock Comments Fixed

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -41,7 +41,7 @@ class Services extends BaseService
     /**
      * Returns the system menu manager
      *
-     * @return Bonfire\Menus\Manager|mixed
+     * @return \Bonfire\Menus\Manager
      */
     public static function menus(bool $getShared = true)
     {

--- a/src/Menus/HasMenuIcons.php
+++ b/src/Menus/HasMenuIcons.php
@@ -7,37 +7,58 @@
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
+ *
+ * php version 8.0
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
 namespace Bonfire\Menus;
 
+/**
+ * Trait HasMenuIcons
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
+ */
 trait HasMenuIcons
 {
     /**
      * FontAwesome 5 icon name
-     *
-     * @var string|null
      */
-    protected $faIcon;
+    protected ?string $faIcon;
 
     /**
-     * URL to icon, if an image.
-     *
-     * @var string|null
+     * URL of the icon, if it's an image.
      */
-    protected $iconUrl;
+    protected ?string $iconUrl;
 
     /**
-     * Sets the FontAwesome icon name, like:
+     * Sets the FontAwesome icon name
      *
-     * - fa-pencil
-     * - fal fa-alarm-clock
+     * Here is an inline example:
      *
-     * @return $this
+     * ```js
+     * setFontAwesomeIcon('fa-pencil');
+     * setFontAwesomeIcon('fal fa-alarm-clock');
+     * ```
+     *
+     * @param string $iconName FontAwesome Icon Class name
+     *
+     * @return self
      */
-    public function setFontAwesomeIcon(string $icon)
+    public function setFontAwesomeIcon(string $iconName)
     {
-        $this->faIcon = $icon;
+        $this->faIcon = $iconName;
 
         return $this;
     }
@@ -45,7 +66,9 @@ trait HasMenuIcons
     /**
      * Sets the URL to the icon, if it's an image.
      *
-     * @return $this
+     * @param string $url Custom Icon URL
+     *
+     * @return self
      */
     public function setIconUrl(string $url)
     {
@@ -55,43 +78,55 @@ trait HasMenuIcons
     }
 
     /**
-     * Returns the full icon tag: either a <i> tag for FontAwesome
-     * icons, or an <img> tag for images.
+     * Returns HTML tag depends Menu Icon type `iconUrl` or `faIcon`
+     *
+     * Returns the full icon tag: either a `<i>` tag for FontAwesome icons,
+     * or an `<img>` tag for images.
+     *
+     * @param string $classOrIconUrl FontAwesome Icon Class Name or Icon URL
+     *
+     * @return string
      */
-    public function icon(string $class = ''): string
+    public function icon(string $classOrIconUrl = ''): string
     {
-        if (! empty($this->faIcon)) {
-            return $this->buildFontAwesomeIconTag($class);
+        if (!empty($this->faIcon)) {
+            return $this->buildFontAwesomeIconTag($classOrIconUrl);
         }
-        if (! empty($this->iconUrl)) {
-            return $this->buildImageIconTag($class);
+        if (!empty($this->iconUrl)) {
+            return $this->buildImageIconTag($classOrIconUrl);
         }
 
         return '';
     }
 
     /**
-     * Returns the full FontAwesome tag.
+     * Returns FontAwesome HTML Icon Tag
+     *
+     * Eg: `<i class="fas fa-users"></i>`
+     *
+     * @param string $className Custom class name for FontAwesome Icon
+     *
+     * @return string
      */
-    protected function buildFontAwesomeIconTag(string $class): string
+    protected function buildFontAwesomeIconTag(string $className): string
     {
-        $class = ! empty($class)
-            ? " {$class}"
-            : '';
+        $class = !empty($className) ? " {$className}" : '';
 
         return "<i class=\"{$this->faIcon}{$class}\"></i>";
     }
 
     /**
-     * Returns a full img tag for our icon.
+     * Returns Image tag for custom icon
+     *
+     * Eg: `<img src="https://example.com" class="some-class"/>`
+     *
+     * @param string $class Custom Icon class name
      *
      * @return string
      */
-    protected function buildImageIconTag(string $class)
+    protected function buildImageIconTag(string $class): string
     {
-        $class = ! empty($class)
-            ? "class=\"{$class}\" "
-            : '';
+        $class = !empty($class) ? "class=\"{$class}\" " : '';
 
         $iconUrl = strpos($this->iconUrl, '://') !== false
             ? $this->iconUrl

--- a/src/Menus/HasMenuIcons.php
+++ b/src/Menus/HasMenuIcons.php
@@ -11,10 +11,7 @@
  * php version 8.0
  *
  * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
  * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
  * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
@@ -22,13 +19,6 @@ namespace Bonfire\Menus;
 
 /**
  * Trait HasMenuIcons
- *
- * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
- * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
- * @see      https://github.com/lonnieezell/Bonfire2/
  */
 trait HasMenuIcons
 {
@@ -84,15 +74,13 @@ trait HasMenuIcons
      * or an `<img>` tag for images.
      *
      * @param string $classOrIconUrl FontAwesome Icon Class Name or Icon URL
-     *
-     * @return string
      */
     public function icon(string $classOrIconUrl = ''): string
     {
-        if (!empty($this->faIcon)) {
+        if (! empty($this->faIcon)) {
             return $this->buildFontAwesomeIconTag($classOrIconUrl);
         }
-        if (!empty($this->iconUrl)) {
+        if (! empty($this->iconUrl)) {
             return $this->buildImageIconTag($classOrIconUrl);
         }
 
@@ -105,12 +93,10 @@ trait HasMenuIcons
      * Eg: `<i class="fas fa-users"></i>`
      *
      * @param string $className Custom class name for FontAwesome Icon
-     *
-     * @return string
      */
     protected function buildFontAwesomeIconTag(string $className): string
     {
-        $class = !empty($className) ? " {$className}" : '';
+        $class = ! empty($className) ? " {$className}" : '';
 
         return "<i class=\"{$this->faIcon}{$class}\"></i>";
     }
@@ -121,12 +107,10 @@ trait HasMenuIcons
      * Eg: `<img src="https://example.com" class="some-class"/>`
      *
      * @param string $class Custom Icon class name
-     *
-     * @return string
      */
     protected function buildImageIconTag(string $class): string
     {
-        $class = !empty($class) ? "class=\"{$class}\" " : '';
+        $class = ! empty($class) ? "class=\"{$class}\" " : '';
 
         $iconUrl = strpos($this->iconUrl, '://') !== false
             ? $this->iconUrl

--- a/src/Menus/Manager.php
+++ b/src/Menus/Manager.php
@@ -11,10 +11,7 @@
  * php version 8.0
  *
  * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
  * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
  * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
@@ -27,13 +24,6 @@ namespace Bonfire\Menus;
  *
  * @method self                createMenu(string $name)
  * @method \Bonfire\Menus\Menu menu(string $name)
- *
- * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
- * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
- * @see      https://github.com/lonnieezell/Bonfire2/
  */
 class Manager
 {
@@ -48,8 +38,6 @@ class Manager
      * Creates a new menu in the system.
      *
      * @param string $name New Menu's name
-     *
-     * @return self
      */
     public function createMenu(string $name): self
     {
@@ -65,9 +53,9 @@ class Manager
      *
      * @return \Bonfire\Menus\Menu
      */
-    public function menu(string $name):Menu
+    public function menu(string $name): Menu
     {
-        if (!isset($this->_menus[$name])) {
+        if (! isset($this->_menus[$name])) {
             $this->createMenu($name);
         }
 

--- a/src/Menus/Manager.php
+++ b/src/Menus/Manager.php
@@ -7,32 +7,53 @@
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
+ *
+ * php version 8.0
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
 namespace Bonfire\Menus;
 
 /**
- * Class Manager
+ * Menus Manager Class
  *
  * The main class used to work with menus in the system.
+ *
+ * @method self                createMenu(string $name)
+ * @method \Bonfire\Menus\Menu menu(string $name)
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 class Manager
 {
     /**
      * A collection of menus currently known about.
      *
-     * @var array
+     * @var array<\Bonfire\Menus\Menu> array of `\Bonfire\Menus\Menu`
      */
-    private $menus = [];
+    private array $_menus = [];
 
     /**
      * Creates a new menu in the system.
      *
-     * @return $this
+     * @param string $name New Menu's name
+     *
+     * @return self
      */
-    public function createMenu(string $name)
+    public function createMenu(string $name): self
     {
-        $this->menus[$name] = new Menu();
+        $this->_menus[$name] = new Menu();
 
         return $this;
     }
@@ -40,14 +61,16 @@ class Manager
     /**
      * Returns the specified menu instance
      *
-     * @return mixed
+     * @param string $name Menu's name
+     *
+     * @return \Bonfire\Menus\Menu
      */
-    public function menu(string $name)
+    public function menu(string $name):Menu
     {
-        if (! isset($this->menus[$name])) {
+        if (!isset($this->_menus[$name])) {
             $this->createMenu($name);
         }
 
-        return $this->menus[$name];
+        return $this->_menus[$name];
     }
 }

--- a/src/Menus/Menu.php
+++ b/src/Menus/Menu.php
@@ -7,36 +7,59 @@
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
+ *
+ * php version 8.0
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
 namespace Bonfire\Menus;
 
+/**
+ * Menu Class
+ *
+ * Represent list of Menu items and collection
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
+ */
 class Menu
 {
     /**
-     * Holds all items/collections that appear
-     * at top level in this menu.
+     * Holds all Menu items or Menu collections that appear at
+     * top level in this menu.
      *
-     * @var array
+     * @var array<\Bonfire\Menus\MenuCollection|\Bonfire\Menus\MenuItem>
      */
-    protected $items = [];
+    protected array $items = [];
 
     /**
-     * Returns all items/collections in the menu.
+     * Returns all Menu items or Menu collections in the menu.
      *
-     * @return array
+     * @return array<\Bonfire\Menus\MenuCollection|\Bonfire\Menus\MenuItem>
      */
-    public function items()
+    public function items(): array
     {
         return $this->items;
     }
 
     /**
-     * Adds a new item
+     * Adds a new Menu item
      *
-     * @return $this
+     * @param \Bonfire\Menus\MenuItem $item Instance of MenuItem
+     *
+     * @return self
      */
-    public function addItem(MenuItem $item)
+    public function addItem(MenuItem $item): self
     {
         $this->items[] = $item;
 
@@ -47,12 +70,16 @@ class Menu
      * Creates a new collection with default values for
      * everything except the `name` and `title`, which are
      * required parameters.
+     *
+     * @param string $name  name or slug of the new Menu Collection
+     * @param string $title Title of the new Menu Collection
+     *
+     * @return \Bonfire\Menus\MenuCollection
      */
     public function createCollection(string $name, string $title): MenuCollection
     {
         $collection = new MenuCollection();
-        $collection->setName($name)
-            ->setTitle($title);
+        $collection->setName($name)->setTitle($title);
 
         $this->items[] = $collection;
 
@@ -63,10 +90,18 @@ class Menu
      * Creates a new collection, if one with $name doesn't exist,
      * and adds the items to the collection.
      *
-     * @return MenuCollection|mixed
+     * @param string $name  name of Menu Collection
+     * @param array  $items Array of Menu Item
+     *
+     * @return \Bonfire\Menus\MenuCollection
      */
-    public function collect(string $name, array $items)
+    public function collect(string $name, array $items): MenuCollection
     {
+        /**
+         *  Get Menu Collection
+         *
+         * @var \Bonfire\Menus\MenuCollection|null $collection
+         */
         $collection = $this->collection($name);
 
         if ($collection === null) {
@@ -84,7 +119,9 @@ class Menu
     /**
      * Locates a collection by name.
      *
-     * @return mixed
+     * @param string $name name of the Menu Collection
+     *
+     * @return \Bonfire\Menus\MenuCollection|null
      */
     public function collection(string $name)
     {
@@ -93,10 +130,14 @@ class Menu
                 return $item;
             }
         }
+
+        return null;
     }
 
     /**
      * Returns an array of all collections stored, if any.
+     *
+     * @return array<\Bonfire\Menus\MenuCollection>
      */
     public function collections(): array
     {

--- a/src/Menus/Menu.php
+++ b/src/Menus/Menu.php
@@ -11,10 +11,7 @@
  * php version 8.0
  *
  * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
  * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
  * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
@@ -24,13 +21,6 @@ namespace Bonfire\Menus;
  * Menu Class
  *
  * Represent list of Menu items and collection
- *
- * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
- * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
- * @see      https://github.com/lonnieezell/Bonfire2/
  */
 class Menu
 {
@@ -56,8 +46,6 @@ class Menu
      * Adds a new Menu item
      *
      * @param \Bonfire\Menus\MenuItem $item Instance of MenuItem
-     *
-     * @return self
      */
     public function addItem(MenuItem $item): self
     {

--- a/src/Menus/MenuCollection.php
+++ b/src/Menus/MenuCollection.php
@@ -11,10 +11,7 @@
  * php version 8.0
  *
  * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
  * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
  * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
@@ -27,13 +24,6 @@ namespace Bonfire\Menus;
  *
  * @property string $name
  * @property string $title
- *
- * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
- * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
- * @see      https://github.com/lonnieezell/Bonfire2/
  */
 class MenuCollection extends MenuItem
 {
@@ -60,8 +50,6 @@ class MenuCollection extends MenuItem
      * Sets the name this collection can be referenced by.
      *
      * @param string $name Name of Menu item
-     *
-     * @return self
      */
     public function setName(string $name): self
     {
@@ -72,8 +60,6 @@ class MenuCollection extends MenuItem
 
     /**
      * Gets the name this collection can be referenced by.
-     *
-     * @return string
      */
     public function name(): string
     {
@@ -84,8 +70,6 @@ class MenuCollection extends MenuItem
      * Sets this collection is collapsible.
      *
      * @param bool $collapse Is collapsible or not
-     *
-     * @return self
      */
     public function setCollapsible(bool $collapse = true): self
     {
@@ -96,8 +80,6 @@ class MenuCollection extends MenuItem
 
     /**
      * Gets this collection is collapsible
-     *
-     * @return bool
      */
     public function isCollapsible(): bool
     {
@@ -108,8 +90,6 @@ class MenuCollection extends MenuItem
      * Adds a single item to the menu.
      *
      * @param \Bonfire\Menus\MenuItem $item Instance of MenuItem
-     *
-     * @return self
      */
     public function addItem(MenuItem $item): self
     {
@@ -122,8 +102,6 @@ class MenuCollection extends MenuItem
      * Add multiple Menu items at once.
      *
      * @param array<\Bonfire\Menus\MenuItem> $items list of MenuItem Instance
-     *
-     * @return self
      */
     public function addItems(array $items): self
     {
@@ -136,8 +114,6 @@ class MenuCollection extends MenuItem
      * Remove Menu Item from this collection
      *
      * @param string $title title of MenuItem that want to remove
-     *
-     * @return void
      */
     public function removeItem(string $title): void
     {
@@ -151,8 +127,6 @@ class MenuCollection extends MenuItem
 
     /**
      * Removes all of the items from this collection.
-     *
-     * @return self
      */
     public function removeAllItems(): self
     {
@@ -178,8 +152,6 @@ class MenuCollection extends MenuItem
      * Is this collection "active"? Used in default admin
      * theme to determine if the sub-navs should be open
      * or flyout.
-     *
-     * @return bool
      */
     public function isActive(): bool
     {
@@ -191,8 +163,6 @@ class MenuCollection extends MenuItem
     /**
      * Sorts the items by the weight, ensuring that bigger
      * weights drop to the bottom.
-     *
-     * @return void
      */
     protected function sortItems(): void
     {

--- a/src/Menus/MenuCollection.php
+++ b/src/Menus/MenuCollection.php
@@ -7,6 +7,15 @@
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
+ *
+ * php version 8.0
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
 namespace Bonfire\Menus;
@@ -18,36 +27,43 @@ namespace Bonfire\Menus;
  *
  * @property string $name
  * @property string $title
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 class MenuCollection extends MenuItem
 {
     use HasMenuIcons;
 
     /**
-     * @var array
+     * Holds all Menu items of a collection
+     *
+     * @var array<\Bonfire\Menus\MenuItem>
      */
-    protected $items = [];
+    protected array $items = [];
 
     /**
      * The name this collection is discovered by.
-     *
-     * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * If true, should be presented as a collapsible menu.
-     *
-     * @var bool
      */
-    protected $collapsible = false;
+    protected bool $collapsible = false;
 
     /**
      * Sets the name this collection can be referenced by.
      *
-     * @return $this
+     * @param string $name Name of Menu item
+     *
+     * @return self
      */
-    public function setName(string $name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
@@ -55,23 +71,34 @@ class MenuCollection extends MenuItem
     }
 
     /**
+     * Gets the name this collection can be referenced by.
+     *
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return $this->name;
     }
 
     /**
-     * @return $this
+     * Sets this collection is collapsible.
+     *
+     * @param bool $collapse Is collapsible or not
+     *
+     * @return self
      */
-    public function setCollapsible(bool $collapse = true): MenuCollection
+    public function setCollapsible(bool $collapse = true): self
     {
         $this->collapsible = $collapse;
 
         return $this;
     }
 
+    /**
+     * Gets this collection is collapsible
+     *
+     * @return bool
+     */
     public function isCollapsible(): bool
     {
         return $this->collapsible;
@@ -80,9 +107,11 @@ class MenuCollection extends MenuItem
     /**
      * Adds a single item to the menu.
      *
-     * @return $this
+     * @param \Bonfire\Menus\MenuItem $item Instance of MenuItem
+     *
+     * @return self
      */
-    public function addItem(MenuItem $item)
+    public function addItem(MenuItem $item): self
     {
         $this->items[] = $item;
 
@@ -90,18 +119,27 @@ class MenuCollection extends MenuItem
     }
 
     /**
-     * Add multiple items at once.
+     * Add multiple Menu items at once.
      *
-     * @return $this
+     * @param array<\Bonfire\Menus\MenuItem> $items list of MenuItem Instance
+     *
+     * @return self
      */
-    public function addItems(array $items)
+    public function addItems(array $items): self
     {
         $this->items = array_merge($this->items, $items);
 
         return $this;
     }
 
-    public function removeItem(string $title)
+    /**
+     * Remove Menu Item from this collection
+     *
+     * @param string $title title of MenuItem that want to remove
+     *
+     * @return void
+     */
+    public function removeItem(string $title): void
     {
         for ($i = 0; $i < count($this->items); $i++) {
             if ($this->items[$i]->title() === $title) {
@@ -114,9 +152,9 @@ class MenuCollection extends MenuItem
     /**
      * Removes all of the items from this collection.
      *
-     * @return $this
+     * @return self
      */
-    public function removeAllItems()
+    public function removeAllItems(): self
     {
         $this->items = [];
 
@@ -124,13 +162,12 @@ class MenuCollection extends MenuItem
     }
 
     /**
-     * Returns all items in the Collection,
-     * sorted by weight, where larger weights
-     * make them fall to the bottom.
+     * Returns all items in the Collection, sorted by weight,
+     * where larger weights make them fall to the bottom.
      *
-     * @return array
+     * @return array<\Bonfire\Menus\MenuItem>
      */
-    public function items()
+    public function items(): array
     {
         $this->sortItems();
 
@@ -138,9 +175,11 @@ class MenuCollection extends MenuItem
     }
 
     /**
-     * Is this collection "active"?
-     * Used in default admin theme to determine
-     * if the subnavs should be open or flyouts.
+     * Is this collection "active"? Used in default admin
+     * theme to determine if the sub-navs should be open
+     * or flyout.
+     *
+     * @return bool
      */
     public function isActive(): bool
     {
@@ -150,21 +189,32 @@ class MenuCollection extends MenuItem
     }
 
     /**
-     * Sorts the items by the weight,
-     * ensuring that bigger weights
-     * drop to the bottom.
+     * Sorts the items by the weight, ensuring that bigger
+     * weights drop to the bottom.
+     *
+     * @return void
      */
-    protected function sortItems()
+    protected function sortItems(): void
     {
-        usort($this->items, static function ($a, $b) {
-            if ($a->weight === $b->weight) {
-                return $a->title <=> $b->title;
-            }
+        usort(
+            $this->items,
+            static function ($a, $b) {
+                if ($a->weight === $b->weight) {
+                    return $a->title <=> $b->title;
+                }
 
-            return $a->weight <=> $b->weight;
-        });
+                return $a->weight <=> $b->weight;
+            }
+        );
     }
 
+    /**
+     * Gets callable of MenuCollection Class
+     *
+     * @param string $key one of the Method name of MenuCollection Class
+     *
+     * @return mixed
+     */
     public function __get(string $key)
     {
         if (method_exists($this, $key)) {

--- a/src/Menus/MenuItem.php
+++ b/src/Menus/MenuItem.php
@@ -11,10 +11,7 @@
  * php version 8.0
  *
  * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
  * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
  * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
@@ -30,13 +27,6 @@ namespace Bonfire\Menus;
  * @property string $title
  * @property string $url
  * @property int    $weight
- *
- * @category Menus
- * @package  Bonfire
- * @author   Lonnie Ezell <lonnieje@gmail.com>
- * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/lonnieezell/Bonfire2/
- * @see      https://github.com/lonnieezell/Bonfire2/
  */
 class MenuItem
 {
@@ -105,8 +95,6 @@ class MenuItem
      * Sets Title of this Menu Item
      *
      * @param string $title Title of Menu Item
-     *
-     * @return self
      */
     public function setTitle(string $title): self
     {
@@ -119,8 +107,6 @@ class MenuItem
      * Sets URL of this Menu Item
      *
      * @param string $url Url of Menu Item
-     *
-     * @return self
      */
     public function setUrl(string $url): self
     {
@@ -133,8 +119,6 @@ class MenuItem
      * Sets the URL via reverse routing, so can use named routes to set the URL by.
      *
      * @param string $name NamedRoute or alias of
-     *
-     * @return self Route for Menu Item
      */
     public function setNamedRoute(string $name): self
     {
@@ -147,8 +131,6 @@ class MenuItem
      * Sets the Alternative Text of this Menu Item
      *
      * @param string $text AltText for Menu Item
-     *
-     * @return self
      */
     public function setAltText(string $text): self
     {
@@ -164,8 +146,6 @@ class MenuItem
      * the unique named route.
      *
      * @param int $weight Weight of Menu Item
-     *
-     * @return self
      */
     public function setWeight(int $weight): self
     {
@@ -184,8 +164,6 @@ class MenuItem
      * Sets the permission required to see this menu item.
      *
      * @param string $permission Permission for user can
-     *
-     * @return self see this menu item
      */
     public function setPermission(string $permission): self
     {
@@ -196,8 +174,6 @@ class MenuItem
 
     /**
      * Gets Title of this Menu Item
-     *
-     * @return string
      */
     public function title(): string
     {
@@ -206,8 +182,6 @@ class MenuItem
 
     /**
      * Gets Url of this Menu Item
-     *
-     * @return string
      */
     public function url(): string
     {
@@ -216,8 +190,6 @@ class MenuItem
 
     /**
      * Gets altText of this Menu Item
-     *
-     * @return string
      */
     public function altText(): string
     {
@@ -226,18 +198,14 @@ class MenuItem
 
     /**
      * Gets Weight of this Menu Item
-     *
-     * @return int
      */
-    public function weight():int
+    public function weight(): int
     {
         return $this->weight ?? 0;
     }
 
     /**
      * Can the active user see this menu item?
-     *
-     * @return bool
      */
     public function userCanSee(): bool
     {

--- a/src/Menus/MenuItem.php
+++ b/src/Menus/MenuItem.php
@@ -7,6 +7,15 @@
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
+ *
+ * php version 8.0
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 
 namespace Bonfire\Menus;
@@ -21,66 +30,68 @@ namespace Bonfire\Menus;
  * @property string $title
  * @property string $url
  * @property int    $weight
+ *
+ * @category Menus
+ * @package  Bonfire
+ * @author   Lonnie Ezell <lonnieje@gmail.com>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/lonnieezell/Bonfire2/
+ * @see      https://github.com/lonnieezell/Bonfire2/
  */
 class MenuItem
 {
     use HasMenuIcons;
 
     /**
-     * @var string|null
+     * Title of Menu Item
      */
-    protected $title;
+    protected ?string $title;
 
     /**
-     * @var string|null
+     * URL of Menu Item
      */
-    protected $url;
+    protected ?string $url;
 
     /**
-     * @var string|null
+     * Alternative Text of Menu Item
      */
-    protected $altText;
+    protected ?string $altText;
 
     /**
      * The 'weight' used for sorting.
-     *
-     * @var int|null
      */
-    protected $weight;
+    protected ?int $weight;
 
     /**
-     * The permission to check to see if the
-     * user can view the menu item or not.
-     *
-     * @var string
+     * The permission to check to see if the user can view the menu item or not.
      */
-    protected $permission;
+    protected string $permission;
 
     /**
-     * Route for use in setting weight
-     * based on values from config
-     * 
-     * @var string
+     * Route for use in setting weight based on values from config
      */
-    private $namedRoute;
+    private string $_namedRoute;
 
+    /**
+     * Undocumented function
+     *
+     * @param array|null $data Array of Menu Item's data
+     */
     public function __construct(?array $data = null)
     {
-        if (!is_array($data)) {
+        if (! is_array($data)) {
             return;
         }
 
         // store the named route to use to draw  the weight of the
         // item from settings
-        if (
-            isset($data['namedRoute'])
-            && is_string($data['namedRoute'])
-        ) {
-            $this->namedRoute = $data['namedRoute'];
+        if (isset($data['namedRoute']) && is_string($data['namedRoute'])) {
+            $this->_namedRoute = $data['namedRoute'];
         }
 
-        if (! isset($data['weight']))
+        if (! isset($data['weight'])) {
             $data['weight'] = 0;
+        }
 
         foreach ($data as $key => $value) {
             $method = 'set' . ucfirst($key);
@@ -91,9 +102,13 @@ class MenuItem
     }
 
     /**
-     * @return $this
+     * Sets Title of this Menu Item
+     *
+     * @param string $title Title of Menu Item
+     *
+     * @return self
      */
-    public function setTitle(string $title)
+    public function setTitle(string $title): self
     {
         $this->title = $title;
 
@@ -101,24 +116,27 @@ class MenuItem
     }
 
     /**
-     * @return $this
+     * Sets URL of this Menu Item
+     *
+     * @param string $url Url of Menu Item
+     *
+     * @return self
      */
-    public function setUrl(string $url)
+    public function setUrl(string $url): self
     {
-        $this->url = strpos($url, '://') !== false
-            ? $url
-            : '/' . ltrim($url, '/ ');
+        $this->url = strpos($url, '://') !== false ? $url : '/' . ltrim($url, '/ ');
 
         return $this;
     }
 
     /**
-     * Sets the URL via reverse routing, so can
-     * use named routes to set the URL by.
+     * Sets the URL via reverse routing, so can use named routes to set the URL by.
      *
-     * @return $this
+     * @param string $name NamedRoute or alias of
+     *
+     * @return self Route for Menu Item
      */
-    public function setNamedRoute(string $name)
+    public function setNamedRoute(string $name): self
     {
         $this->url = url_to($name);
 
@@ -126,9 +144,13 @@ class MenuItem
     }
 
     /**
-     * @return $this
+     * Sets the Alternative Text of this Menu Item
+     *
+     * @param string $text AltText for Menu Item
+     *
+     * @return self
      */
-    public function setAltText(string $text)
+    public function setAltText(string $text): self
     {
         $this->altText = $text;
 
@@ -137,22 +159,23 @@ class MenuItem
 
     /**
      * Sets the "weight" of the menu item.
-     * The large the value, the later in the menu
-     * it will appear.
-     * Uses the value from Config/Bonfire.php $menuWeights
-     * if it is set, key is the unique named route.
+     * The large the value, the later in the menu it will appear.
+     * Uses the value from Config/Bonfire.php $menuWeights if it is set, key is
+     * the unique named route.
      *
-     * @return $this
+     * @param int $weight Weight of Menu Item
+     *
+     * @return self
      */
-    public function setWeight(int $weight)
+    public function setWeight(int $weight): self
     {
-        if (
-            $this->namedRoute
-            && isset(setting('Bonfire.menuWeights')[$this->namedRoute])
-        )
-            $this->weight = setting('Bonfire.menuWeights')[$this->namedRoute];
-        else
+        $defaultMenuWeight = setting('Bonfire.menuWeights');
+
+        if ($this->_namedRoute && isset($defaultMenuWeight[$this->_namedRoute])) {
+            $this->weight = setting('Bonfire.menuWeights')[$this->_namedRoute];
+        } else {
             $this->weight = $weight;
+        }
 
         return $this;
     }
@@ -160,9 +183,11 @@ class MenuItem
     /**
      * Sets the permission required to see this menu item.
      *
-     * @return $this
+     * @param string $permission Permission for user can
+     *
+     * @return self see this menu item
      */
-    public function setPermission(string $permission)
+    public function setPermission(string $permission): self
     {
         $this->permission = $permission;
 
@@ -170,39 +195,49 @@ class MenuItem
     }
 
     /**
+     * Gets Title of this Menu Item
+     *
      * @return string
      */
-    public function title()
+    public function title(): string
     {
         return $this->title;
     }
 
     /**
+     * Gets Url of this Menu Item
+     *
      * @return string
      */
-    public function url()
+    public function url(): string
     {
         return $this->url;
     }
 
     /**
+     * Gets altText of this Menu Item
+     *
      * @return string
      */
-    public function altText()
+    public function altText(): string
     {
         return $this->altText;
     }
 
     /**
+     * Gets Weight of this Menu Item
+     *
      * @return int
      */
-    public function weight()
+    public function weight():int
     {
         return $this->weight ?? 0;
     }
 
     /**
      * Can the active user see this menu item?
+     *
+     * @return bool
      */
     public function userCanSee(): bool
     {
@@ -216,6 +251,13 @@ class MenuItem
         return auth()->user()->can($this->permission);
     }
 
+    /**
+     * Gets callable of MenuItem Class
+     *
+     * @param string $key one of the Method name of MenuItem Class
+     *
+     * @return mixed
+     */
     public function __get(string $key)
     {
         if (method_exists($this, $key)) {


### PR DESCRIPTION
Fix Menu Component invalid `@return` type, other PHP DocBlock issue & renaming properties based on `php-cs`. There are no changes on the source code beside renamed some classes private properties and DocBlock.