### PR TITLE
Hide empty collection

### DIFF
--- a/src/Menus/MenuCollection.php
+++ b/src/Menus/MenuCollection.php
@@ -179,6 +179,24 @@ class MenuCollection extends MenuItem
     }
 
     /**
+     * Returns true if the collection contains at least one item that is
+     * visible to current user, false otherwise
+     */
+    public function hasVisibleItems(): bool
+    {
+        $visible = false;
+
+        foreach ($this->items as $item) {
+            if ($item->userCanSee()) {
+                $visible = true;
+                break;
+            }
+        }
+
+        return $visible;
+    }
+
+    /**
      * Gets callable of MenuCollection Class
      *
      * @param string $key one of the Method name of MenuCollection Class

--- a/tests/Menus/MenuCollectionTest.php
+++ b/tests/Menus/MenuCollectionTest.php
@@ -104,7 +104,9 @@ final class MenuCollectionTest extends TestCase
     {
         // first create user:
         $user = fake(UserModel::class);
+        /** @phpstan-ignore-next-line */
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'alsdkfja;sldkfj']);
+        /** @phpstan-ignore-next-line */
         $user->addGroup('admin');
 
         // immitate user login

--- a/tests/Menus/MenuCollectionTest.php
+++ b/tests/Menus/MenuCollectionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Menus;
 
 use Bonfire\Menus\MenuCollection;
 use Bonfire\Menus\MenuItem;
+use Bonfire\Users\Models\UserModel;
 use Tests\Support\TestCase;
 
 /**
@@ -97,5 +98,48 @@ final class MenuCollectionTest extends TestCase
         $this->assertCount(2, $items);
         $this->assertSame('Item 2', $items[0]->title);
         $this->assertSame('Item 1', $items[1]->title);
+    }
+
+    public function testHasVisibleItems()
+    {
+        // first create user:
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'alsdkfja;sldkfj']);
+        $user->addGroup('admin');
+
+        // immitate user login
+        $response = $this->post(route_to('login'), [
+            'email'    => 'foo@example.com',
+            'password' => 'alsdkfja;sldkfj',
+        ]);
+        // check if login successfull
+        $response->assertSessionHas('logged_in');
+
+        // create menu collection to test
+        $collection = new MenuCollection(['name' => 'Bar']);
+
+        // add item that will not be visible to admin:
+        $superadminMenu = new MenuItem([
+            'title'           => 'Item not seen to admin',
+            'namedRoute'      => 'user-list',
+            'fontAwesomeIcon' => 'fas fa-user-cog',
+            'permission'      => 'admin.settings',
+        ]);
+        $collection->addItem($superadminMenu);
+
+        // test that collection does not have visible items: 
+        $this->assertFalse($collection->hasVisibleItems());
+
+        // add item that would be visible to admin
+        $adminMenu = new MenuItem([
+            'title'           => 'Item available to admin',
+            'namedRoute'      => 'user-list',
+            'fontAwesomeIcon' => 'fas fa-user',
+            'permission'      => 'admin.access',
+        ]);
+        $collection->addItem($adminMenu);
+        
+        // test that collection now does have visible items: 
+        $this->assertTrue($collection->hasVisibleItems());
     }
 }

--- a/themes/Admin/Components/sidebar.php
+++ b/themes/Admin/Components/sidebar.php
@@ -18,42 +18,42 @@
 
     <?php if (isset($menu)) : ?>
         <?php foreach ($menu->collections() as $collection) : ?>
+            <?php if ($collection->hasVisibleItems()) : ?>
+                <div>
+                    <ul class="nav flex-column px-0">
+                        <?php if ($collection->isCollapsible()) : ?>
+                            <li class="nav-item">
+                                <a class="nav-link <?= $collection->isActive() ? 'active' : '' ?>" href="#">
+                                    <?= $collection->icon ?>
+                                    <span><?= $collection->title ?></span>
+                                </a>
+                            </li>
+                            <ul class="nav subnav flex-column mb-2  <?= $collection->isActive() ? 'active' : 'flyout' ?>">
+                                <li class="nav-item nav-title">
+                                    <a class="nav-link">
+                                        <?= $collection->title ?>
+                                    </a>
+                                </li>
+                        <?php endif ?>
 
-        <div>
-            <ul class="nav flex-column px-0">
-                <?php if ($collection->isCollapsible()) : ?>
-                    <li class="nav-item">
-                        <a class="nav-link <?= $collection->isActive() ? 'active' : '' ?>" href="#">
-                            <?= $collection->icon ?>
-                            <span><?= $collection->title ?></span>
-                        </a>
-                    </li>
-                    <ul class="nav subnav flex-column mb-2  <?= $collection->isActive() ? 'active' : 'flyout' ?>">
-                        <li class="nav-item nav-title">
-                            <a class="nav-link">
-                                <?= $collection->title ?>
-                            </a>
-                        </li>
-                <?php endif ?>
-
-
-                <?php foreach ($collection->items() as $item) : ?>
-                    <?php if ($item->userCanSee()): ?>
-                        <li class="nav-item">
-                            <a class="nav-link <?= url_is($item->url . '*') ? 'active' : '' ?>" href="<?= $item->url ?>">
-                                <?php if (! $collection->isCollapsible()) : ?>
-                                    <?= $item->icon ?>
-                                <?php endif ?>
-                                <span><?= $item->title ?></span>
-                            </a>
-                        </li>
-                    <?php endif ?>
-                <?php endforeach ?>
-                <?php if ($collection->isCollapsible()) : ?>
+                        <?php foreach ($collection->items() as $item) : ?>
+                            <?php if ($item->userCanSee()): ?>
+                                <li class="nav-item">
+                                    <a class="nav-link <?= url_is($item->url . '*') ? 'active' : '' ?>" href="<?= $item->url ?>">
+                                        <?php if (! $collection->isCollapsible()) : ?>
+                                            <?= $item->icon ?>
+                                        <?php endif ?>
+                                        <span><?= $item->title ?></span>
+                                    </a>
+                                </li>
+                            <?php endif ?>
+                        <?php endforeach ?>
+                        <?php if ($collection->isCollapsible()) : ?>
+                            </ul>
+                        <?php endif ?>
                     </ul>
-                <?php endif ?>
-            </ul>
-        </div>
+                </div>
+            <?php endif ?>
         <?php endforeach ?>
     <?php endif ?>
 </div>


### PR DESCRIPTION
Currently when menu collection is empty (e.g., since the user does not have permission to see the contents of what is in the menu) it's heading is still displayed. The proposed changes hide collection in such case.