### PR TITLE
Fix validation placeholder error (#351)

### DIFF
--- a/src/Users/Config/Users.php
+++ b/src/Users/Config/Users.php
@@ -56,20 +56,25 @@ class Users extends BaseConfig
      * Validation rules used when saving a user.
      */
     public $validation = [
-        'email'      => [
-            'label' => 'Email',
-            'rules' => 'required|valid_email|unique_email[{id}]',
-            'errors'=> [
+        'id' => [
+            // Needed for the id in email test;
+            // see https://codeigniter4.github.io/userguide/installation/upgrade_435.html
+            'rules' => 'permit_empty|is_natural_no_zero',
+        ],
+        'email' => [
+            'label'  => 'Email',
+            'rules'  => 'required|valid_email|unique_email[{id}]',
+            'errors' => [
                 'unique_email' => 'This email is already in use. Could belong to a current or a deleted user.',
             ],
         ],
-        'username'   => [
+        'username' => [
             'label' => 'Username', 'rules' => 'required|string|is_unique[users.username,id,{id}]',
         ],
         'first_name' => [
             'label' => 'First Name', 'rules' => 'permit_empty|string|min_length[3]',
         ],
-        'last_name'  => [
+        'last_name' => [
             'label' => 'Last Name', 'rules' => 'permit_empty|string|min_length[3]',
         ],
     ];


### PR DESCRIPTION
The error is a result of the breaking change to CI 4.3.5 (https://codeigniter4.github.io/userguide/installation/upgrade_435.html) 

Adding a rule in Users.php 

**Note for those affected by the bug**: you should manually update the Users.php config file in app/Config, since it is a copy of the file updated with this fix created by the Bonfire install script. 