### PR TITLE
Turn "Last Active" checkbox filter to radio filter

### DIFF
--- a/docs/building_admin_modules/filters.md
+++ b/docs/building_admin_modules/filters.md
@@ -14,6 +14,7 @@ You specify the available filters within your Model, using a class property name
 protected $filters = [
     'column_name' => [
         'title' => 'Column Title',
+        'type' => 'radio',
         'options' => ['one' => 'Option 1', 'two' => 'Option 2']
     ],
     'column_two' => [
@@ -24,9 +25,13 @@ protected $filters = [
 ```
 
 The key of each array element is the name of the `column` that you wish to filter on. The column must be within the
-table for the model (see below for other options). It is then described by an array with the keys `title`, and `options`.
+table for the model (see below for other options). It is then described by an array with the keys `title`, `options`, and 
+optional key `type`. 
 Title is the display title for that group of options. The `options` value is typically an array of keys and their display
-values that the column should be filtered by. The keys must match valid values within the database.
+values that the column should be filtered by. The keys must match valid values within the database. Key `type` signifies if
+the filter should be composed of checkboxes (default) or radio's. If it is omitted, the default value `checkbox` would be 
+assumed. In case `type` => `radio` is specified, the last option in the `options` array will be pre-selected in the filter
+UI, so it should probably contain value representing all entries.
 
 Sometimes you need to pull values from a config file, or another table, etc, in order to provide the list of options.
 In this case, you can use the string `methodName` where `methodName` is a method within the model to call

--- a/src/Users/Models/UserFilter.php
+++ b/src/Users/Models/UserFilter.php
@@ -34,18 +34,21 @@ class UserFilter extends UserModel
             'options' => [0 => 'Inactive', 1 => 'Active'],
         ],
         'last_active' => [
-            'title'   => 'Last Active',
+            'title'   => 'Last Active Within',
+            'type'    => 'radio',
             'options' => [
-                1   => '1 day',
-                2   => '2 days',
-                3   => '3 days',
-                7   => '1 week',
-                14  => '2 weeks',
-                30  => '1 month',
-                90  => '3 months',
-                180 => '6 months',
-                365 => '1 year',
-                366 => '> 1 year',
+                1       => '1 day',
+                2       => '2 days',
+                3       => '3 days',
+                7       => '1 week',
+                14      => '2 weeks',
+                30      => '1 month',
+                90      => '3 months',
+                180     => '6 months',
+                365     => '1 year',
+                'any'   => 'any time',
+                'never' => 'never',
+                'all'   => 'show all',
             ],
         ],
     ];
@@ -75,11 +78,14 @@ class UserFilter extends UserModel
             $this->whereIn('users.active', $params['active']);
         }
 
-        if (isset($params['last_active']) && count($params['last_active'])) {
-            // We only use the largest value
-            $days = max($params['last_active']);
-            $this->where('last_active >=', Time::now()->subDays($days)->toDateTimeString());
+        if (isset($params['last_active']) && is_numeric($params['last_active'])) {
+            $this->where('last_active >=', Time::now()->subDays($params['last_active'])->toDateTimeString());
+        } elseif (isset($params['last_active']) && $params['last_active'] === 'any') {
+            $this->where('last_active !=', null);
+        } elseif (isset($params['last_active']) && $params['last_active'] === 'never') {
+            $this->where('last_active', null);
         }
+        // omitting 'where' for $params['last_active'] == 'all'
 
         // if we need second query to avoid duplicates:
         if ($secondQuery) {

--- a/src/Views/_filter_list.php
+++ b/src/Views/_filter_list.php
@@ -7,19 +7,29 @@
     >
         <?= csrf_field() ?>
 
-        <?php foreach ($filters as $key => $filter): ?>
+        <?php foreach ($filters as $key => $filter) : ?>
             <h2><?= $filter['title'] ?></h2>
 
             <ul class="list-unstyled">
-            <?php foreach ($filter['options'] as $value => $name): ?>
-                <li class="form-check">
-                    <input class="form-check-input filter-check" type="checkbox" name="filters[<?= $key ?>][<?= $value ?>]"
-                           value="<?= $value ?>" id="<?= $key . ':' . $value ?>>">
-                    <label class="form-check-label" for="<?= $key . ':' . $value ?>">
-                        <?= $name ?>
-                    </label>
-                </li>
-            <?php endforeach ?>
+            <?php if (isset($filter['type']) && $filter['type'] === 'radio'): ?>
+                <?php foreach ($filter['options'] as $value => $name): ?>
+                    <li class="form-check">
+                        <input class="form-check-input filter-check" type="radio" name="filters[<?= $key ?>]" value="<?= $value ?>" id="<?= $key . ':' . $value ?>>" <?= $key === 'all' ?: ' checked' ?>>
+                        <label class="form-check-label" for="<?= $key . ':' . $value ?>">
+                            <?= $name ?>
+                        </label>
+                    </li>
+                <?php endforeach ?>
+            <?php else :  ?>
+                <?php foreach ($filter['options'] as $value => $name) : ?>
+                    <li class="form-check">
+                        <input class="form-check-input filter-check" type="checkbox" name="filters[<?= $key ?>][<?= $value ?>]" value="<?= $value ?>" id="<?= $key . ':' . $value ?>>">
+                        <label class="form-check-label" for="<?= $key . ':' . $value ?>">
+                            <?= $name ?>
+                        </label>
+                    </li>
+                <?php endforeach ?>
+            <?php endif; ?>
             </ul>
         <?php endforeach ?>
     </form>


### PR DESCRIPTION
Using checkboxes in filter where you can check multiple items but only one is used is confusing. I have turned the Last Active filter to `radio` type filter, where you can only select one option. Also, as once selected a radio cannot be unchecked, I added "show all" preselected option, an option to select users that have logged in at any time and an option to select users that have never logged in. 

This also adds a general functionality to use `radio` type filter widget in custom modules and corresponding documentation updates.