### PR TITLE
Re-enable mobile view, add more responsiveness to layout and tables

### DIFF
--- a/src/Recycler/Views/listResource.php
+++ b/src/Recycler/Views/listResource.php
@@ -26,41 +26,42 @@
 
         <?php if (isset($items) && count($items)) : ?>
             <p><?=lang('Recycler.resultLabel', [$pager->getTotal()])?></p>
-
-            <table class="table table-striped table-hover">
-                <thead>
-                <tr>
-                <?php foreach ($currentResource['localizedColumns'] as $column) : ?>
-                    <th><?= esc(ucwords(str_replace('_', ' ', $column))) ?></th>
-                <?php endforeach ?>
-                    <th></th>
-                </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($items as $item) : ?>
-                        <tr>
-                        <?php foreach ($currentResource['columns'] as $column) : ?>
-                            <td><?= esc($item[$column] ?? '') ?></td>
-                        <?php endforeach ?>
-                            <td class="text-end">
-                                <a href="<?= url_to('recycler-restore', $currentAlias, $item['id']) ?>"
-                                   class="text-success" title="<?= lang('Recycler.restoreMsgTitle') ?>"
-                                   onclick="return confirm('<?= lang('Recycler.restoreMsgContent') ?>');"
-                                >
-                                    <i class="fas fa-trash-restore"></i>
-                                </a>
-                                &nbsp;
-                                <a href="<?= url_to('recycler-purge', $currentAlias, $item['id']) ?>"
-                                   class="text-danger" title="<?= lang('Recycler.purgeMsgTitle') ?>"
-                                   onclick="return confirm('<?= lang('Recycler.purgeMsgContent') ?>');"
-                                >
-                                    <i class="fas fa-minus-circle"></i>
-                                </a>
-                            </td>
-                        </tr>
+            <div class="table-responsive">
+                <table class="table table-striped table-hover">
+                    <thead>
+                    <tr>
+                    <?php foreach ($currentResource['localizedColumns'] as $column) : ?>
+                        <th><?= esc(ucwords(str_replace('_', ' ', $column))) ?></th>
                     <?php endforeach ?>
-                </tbody>
-            </table>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($items as $item) : ?>
+                            <tr>
+                            <?php foreach ($currentResource['columns'] as $column) : ?>
+                                <td><?= esc($item[$column] ?? '') ?></td>
+                            <?php endforeach ?>
+                                <td class="text-end">
+                                    <a href="<?= url_to('recycler-restore', $currentAlias, $item['id']) ?>"
+                                    class="text-success" title="<?= lang('Recycler.restoreMsgTitle') ?>"
+                                    onclick="return confirm('<?= lang('Recycler.restoreMsgContent') ?>');"
+                                    >
+                                        <i class="fas fa-trash-restore"></i>
+                                    </a>
+                                    &nbsp;
+                                    <a href="<?= url_to('recycler-purge', $currentAlias, $item['id']) ?>"
+                                    class="text-danger" title="<?= lang('Recycler.purgeMsgTitle') ?>"
+                                    onclick="return confirm('<?= lang('Recycler.purgeMsgContent') ?>');"
+                                    >
+                                        <i class="fas fa-minus-circle"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        <?php endforeach ?>
+                    </tbody>
+                </table>
+            </div>
         <?php else : ?>
             <div class="alert alert-info">
             <?= lang('Recycler.notFound', [$currentAlias]) ?>

--- a/src/Users/Views/_row_info.php
+++ b/src/Users/Views/_row_info.php
@@ -2,7 +2,7 @@
 <td><a href="<?= $user->adminLink() ?>"><?= esc($user->username) ?></a></td>
 <td><?= $user->groupsList() ?></td>
 <td><?= $user->last_active !== null ? $user->last_active->humanize() : 'never' ?></td>
-<td class="d-flex justify-content-end">
+<td class="justify-content-end">
     <?php if (auth()->user()->can('users.edit') || auth()->user()->can('users.delete')): ?>
         <!-- Action Menu -->
         <div class="dropdown">

--- a/src/Users/Views/_table.php
+++ b/src/Users/Views/_table.php
@@ -1,20 +1,22 @@
-<table class="table table-hover">
-    <?= $this->include('_table_head') ?>
-    <tbody>
-    <?php if (isset($users) && count($users)) : ?>
-        <?php foreach ($users as $user) : ?>
-            <tr>
-                <?php if (auth()->user()->can('users.delete')): ?>
-                    <td>
-                        <input type="checkbox" name="selects[<?= $user->id ?>]" class="form-check">
-                    </td>
-                <?php endif ?>
-                <?= view('Bonfire\Users\Views\_row_info', ['user' => $user]) ?>
-            </tr>
-        <?php endforeach ?>
-    <?php endif ?>
-    </tbody>
-</table>
+<div class="table-responsive">
+    <table class="table table-hover">
+        <?= $this->include('_table_head') ?>
+        <tbody>
+        <?php if (isset($users) && count($users)) : ?>
+            <?php foreach ($users as $user) : ?>
+                <tr>
+                    <?php if (auth()->user()->can('users.delete')) : ?>
+                        <td>
+                            <input type="checkbox" name="selects[<?= $user->id ?>]" class="form-check">
+                        </td>
+                    <?php endif ?>
+                    <?= view('Bonfire\Users\Views\_row_info', ['user' => $user]) ?>
+                </tr>
+            <?php endforeach ?>
+        <?php endif ?>
+        </tbody>
+    </table>
+</div>
 
 <?php if (auth()->user()->can('users.delete')) : ?>
     <input type="submit" value="Delete Selected" class="btn btn-sm btn-outline-danger" />

--- a/src/Users/Views/permissions.php
+++ b/src/Users/Views/permissions.php
@@ -18,31 +18,32 @@
             <p>These permissions are applied in addition to any allowed by the user's groups.</p>
 
             <p>Indeterminate checkboxes indicate the permission is already available from one or more groups the user is a part of.</p>
-
-            <table class="table table-striped">
-                <thead>
-                    <tr>
-                        <th style="width: 3rem"></th>
-                        <th>Permission</th>
-                        <th>Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-                <?php foreach ($permissions as $permission => $description) : ?>
-                    <tr>
-                        <td>
-                            <input class="form-check-input <?= $user->can($permission) ? 'in-group' : '' ?>" type="checkbox" name="permissions[]" value="<?= $permission ?>"
-                                <?php if ($user->hasPermission($permission)) : ?>
-                                    checked
-                                <?php endif ?>
-                            >
-                        </td>
-                        <td><?= $permission ?></td>
-                        <td><?= $description ?></td>
-                    </tr>
-                <?php endforeach ?>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th style="width: 3rem"></th>
+                            <th>Permission</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($permissions as $permission => $description) : ?>
+                        <tr>
+                            <td>
+                                <input class="form-check-input <?= $user->can($permission) ? 'in-group' : '' ?>" type="checkbox" name="permissions[]" value="<?= $permission ?>"
+                                    <?php if ($user->hasPermission($permission)) : ?>
+                                        checked
+                                    <?php endif ?>
+                                >
+                            </td>
+                            <td><?= $permission ?></td>
+                            <td><?= $description ?></td>
+                        </tr>
+                    <?php endforeach ?>
+                    </tbody>
+                </table>
+            </div>
         </fieldset>
 
         <div class="text-end">

--- a/src/View/Metadata.php
+++ b/src/View/Metadata.php
@@ -19,7 +19,7 @@ class Metadata
 
         $this->title  = setting('Site.siteName');
         $this->meta[] = ['charset' => 'UTF-8'];
-        $this->meta[] = ['viewport' => 'width=device-width, initial-scale=1'];
+        $this->meta[] = ['name' => 'viewport', 'content' => 'width=device-width, initial-scale=1'];
     }
 
     /**

--- a/tests/View/MetadataTest.php
+++ b/tests/View/MetadataTest.php
@@ -31,7 +31,7 @@ final class MetadataTest extends TestCase
     {
         $this->assertSame(
             '<meta charset="UTF-8" >' . "\n" .
-            '<meta viewport="width=device-width, initial-scale=1" >' . "\n",
+            '<meta name="viewport" content="width=device-width, initial-scale=1" >' . "\n",
             $this->meta->render('meta')
         );
     }

--- a/themes/Admin/Components/admin-box.php
+++ b/themes/Admin/Components/admin-box.php
@@ -1,3 +1,3 @@
-<div class="bg-white p-4 mb-5 border rounded-3 shadow-sm">
+<div class="bg-white p-2 p-sm-4 mb-5 border rounded-3 shadow-sm">
     <?= $slot ?>
 </div>

--- a/themes/Admin/Search/users.php
+++ b/themes/Admin/Search/users.php
@@ -1,15 +1,17 @@
-<table class="table table-hover">
-    <?= $this->setData(['headers' => [
-        'email'       => lang('Bonfire.email'),
-        'username'    => lang('Bonfire.username'),
-        'groups'      => lang('Bonfire.groups'),
-        'last_active' => lang('Bonfire.lastActive'),
-    ]])->include('_table_head') ?>
-    <tbody>
-    <?php foreach ($rows as $user) : ?>
-        <tr>
-            <?= view('Bonfire\Users\Views\_row_info', ['user' => $user]) ?>
-        </tr>
-    <?php endforeach ?>
-    </tbody>
-</table>
+<div class="table-responsive">
+    <table class="table table-hover">
+        <?= $this->setData(['headers' => [
+            'email'       => lang('Bonfire.email'),
+            'username'    => lang('Bonfire.username'),
+            'groups'      => lang('Bonfire.groups'),
+            'last_active' => lang('Bonfire.lastActive'),
+        ]])->include('_table_head') ?>
+        <tbody>
+        <?php foreach ($rows as $user) : ?>
+            <tr>
+                <?= view('Bonfire\Users\Views\_row_info', ['user' => $user]) ?>
+            </tr>
+        <?php endforeach ?>
+        </tbody>
+    </table>
+</div>

--- a/themes/Admin/_header.php
+++ b/themes/Admin/_header.php
@@ -1,10 +1,12 @@
 <header class="navbar navbar-light flex-md-nowrap p-0 shadow-sm d-flex">
-    <button class="navbar-toggler d-sm-none collapsed mx-2 border-none" type="button"
-        @click="open = ! open"
-    >
-        <span class="navbar-toggler-icon"></span>
-    </button>
-
+<?php
+/** disable button untill a more elegant solution is
+ * found. The menu can be toggled using the bottom-left expand button anyway
+ * <button class="navbar-toggler d-sm-none collapsed mx-2 border-none" type="button" @click="open = ! open">
+ *     <span class="navbar-toggler-icon"></span>
+ * </button>
+ */
+?>
     <!-- Search Form -->
     <form action="<?= url_to('search') ?>" method="post" class="flex-grow-1">
         <?= csrf_field() ?>

--- a/themes/Admin/master.php
+++ b/themes/Admin/master.php
@@ -41,7 +41,7 @@
         <main class="ms-sm-auto flex-grow-1" style="overflow: auto">
             <?= $this->include('_header') ?>
 
-            <div class="px-md-4 vh-100" style="margin-top: -48px; padding-top: 48px;">
+            <div class="px-2 px-md-4 vh-100" style="margin-top: -48px; padding-top: 48px;">
                 <?= $this->renderSection('main') ?>
             </div>
         </main>

--- a/themes/Admin/master.php
+++ b/themes/Admin/master.php
@@ -23,7 +23,7 @@
     </div>
 <?php endif ?>
 
-<div class="main <?= site_offline() ? 'offline' : '' ?>" x-data="{open: true}" >
+<div class="main <?= site_offline() ? 'offline' : '' ?>" x-data="{open: (window.innerWidth >= 576)}">
     <div class="h-100 d-flex align-items-stretch">
         <nav id="sidebars" class="sidebar" x-bind:class="{ 'collapsed': ! open }">
             <div class="sidebar-wrap  h-100 position-relative">


### PR DESCRIPTION
These commits are interrelated: they: 
* restore the mobile view (was not fixed after migrating from previous Bootstrap version), 
* add responsiveness to tables, 
* fix padding for some components, 
* make the menu open collapsed in case the screen width is below Bootstrap 5 SM breakpoint,
* hide the hamburger menu (at least for now, until a better solution is found) - for now the same purpose is served by the expand/collapse bottom-left button.

In case not all changes are acceptable, I can submit them as separate PRs.

View before reenabling mobile view: 
![paveikslas](https://github.com/lonnieezell/Bonfire2/assets/2669306/7871c3db-51d6-4b63-aa03-a117a0a074b1)

View after reenabling mobile view, before other fixes: 
![paveikslas](https://github.com/lonnieezell/Bonfire2/assets/2669306/a68c9361-2a66-438b-bca7-043f5200eb28)

View after fixes: 
![paveikslas](https://github.com/lonnieezell/Bonfire2/assets/2669306/44dc10f6-afbf-4c13-8fc4-751c9dda5aad)
