### PR TITLE
Avatar image functionality improvement: deleting, downsizing

### DIFF
--- a/src/Users/Config/Routes.php
+++ b/src/Users/Config/Routes.php
@@ -11,6 +11,7 @@ $routes->group(ADMIN_AREA, ['namespace' => '\Bonfire\Users\Controllers'], static
     $routes->get('users/new', 'UserController::create', ['as' => 'user-new']);
     $routes->get('users/(:num)', 'UserController::edit/$1', ['as' => 'user-edit']);
     $routes->get('users/(:num)/delete', 'UserController::delete/$1', ['as' => 'user-delete']);
+    $routes->get('users/(:num)/deleteAvatar', 'UserController::deleteAvatar/$1', ['as' => 'user-avatar-delete']);
     $routes->post('users/(:num)/save', 'UserController::save/$1', ['as' => 'user-save']);
     $routes->post('users/(:num)/changePassword', 'UserController::changePassword/$1', ['as' => 'user-pass-change']);
     $routes->post('users/save', 'UserController::save');

--- a/src/Users/Config/Users.php
+++ b/src/Users/Config/Users.php
@@ -51,6 +51,18 @@ class Users extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
+     * Uploaded Image Manipulation
+     * --------------------------------------------------------------------------
+     *
+     * Should uploaded avatar be resized? 
+     * Possible values either false or image max size of any dimension in pixels
+     */
+    public $avatarResize = false;
+
+
+
+    /**
+     * --------------------------------------------------------------------------
      * Additional User Fields
      * --------------------------------------------------------------------------
      * Validation rules used when saving a user.

--- a/src/Users/Config/Users.php
+++ b/src/Users/Config/Users.php
@@ -51,15 +51,27 @@ class Users extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
-     * Uploaded Image Manipulation
+     * Avatar Upload directory
+     * --------------------------------------------------------------------------
+     * relative to FCPATH and base_url
+     */
+
+    public $avatarDirectory = 'uploads/avatars';
+
+    /**
+     * --------------------------------------------------------------------------
+     * Uploaded Avatar Image Manipulation
      * --------------------------------------------------------------------------
      *
-     * Should uploaded avatar be resized? 
-     * Possible values either false or image max size of any dimension in pixels
+     * Should uploaded avatar be resized? (bool)
+     * If so, what is the maximum size (vertical or horizontal, whichever
+     * bigger), in px? (int)
+     * $avatarResizeFloor is the minimum size of an avatar (set to 32 as required by
+     * toolbar avatar size)
      */
     public $avatarResize = false;
-
-
+    public $avatarSize = 140;
+    public $avatarResizeFloor = 32;
 
     /**
      * --------------------------------------------------------------------------

--- a/src/Users/Controllers/UserController.php
+++ b/src/Users/Controllers/UserController.php
@@ -165,7 +165,7 @@ class UserController extends AdminController
                 $avatarResize     = setting('Users.avatarResize') ?? false;
                 $maxDimension     = setting('Users.avatarSize') ?? 140;
                 [$width, $height] = getimagesize($file->getPathname());
-                if ($avatarResize && ($width > $maxDimension || $height > $maxDimension)) {
+                if ($avatarResize && ($width > (int) $maxDimension || $height > (int) $maxDimension)) {
                     $image = service('image')->withFile($file->getPathname());
                     $image->resize($maxDimension, $maxDimension, true);
                     $image->save();

--- a/src/Users/Controllers/UserSettingsController.php
+++ b/src/Users/Controllers/UserSettingsController.php
@@ -55,6 +55,8 @@ class UserSettingsController extends BaseController
         $rules = [
             'minimumPasswordLength' => 'required|integer|greater_than[6]',
             'defaultGroup'          => 'required|string',
+            'avatarResize'          => 'required|in_list[0,1]',
+            'avatarSize'            => 'required_with[avatarResize]|integer|greater_than_equal_to[' . (setting('Users.avatarSizeFloor') ?? '32') . ']',
         ];
 
         if (! $this->validate($rules)) {
@@ -82,6 +84,10 @@ class UserSettingsController extends BaseController
         setting('Users.useGravatar', $this->request->getPost('useGravatar') ?? false);
         setting('Users.gravatarDefault', $this->request->getPost('gravatarDefault'));
         setting('Users.avatarNameBasis', $this->request->getPost('avatarNameBasis'));
+        setting('Users.avatarResize', (bool) $this->request->getPost('avatarResize'));
+        if ($this->request->getPost('avatarResize') == 1) {
+            setting('Users.avatarSize', (int) $this->request->getPost('avatarSize'));
+        }
 
         alert('success', lang('Bonfire.resourcesSaved', ['settings']));
 

--- a/src/Users/Controllers/UserSettingsController.php
+++ b/src/Users/Controllers/UserSettingsController.php
@@ -85,7 +85,7 @@ class UserSettingsController extends BaseController
         setting('Users.gravatarDefault', $this->request->getPost('gravatarDefault'));
         setting('Users.avatarNameBasis', $this->request->getPost('avatarNameBasis'));
         setting('Users.avatarResize', (bool) $this->request->getPost('avatarResize'));
-        if ($this->request->getPost('avatarResize') == 1) {
+        if ((int) $this->request->getPost('avatarResize') === 1) {
             setting('Users.avatarSize', (int) $this->request->getPost('avatarSize'));
         }
 

--- a/src/Users/Models/UserModel.php
+++ b/src/Users/Models/UserModel.php
@@ -69,6 +69,7 @@ class UserModel extends ShieldUsers
             return $data;
         }
 
+        /** @phpstan-ignore-next-line  TODO: any better way of accessing $avatar on user objet? It works, but phpstan complains */
         $userAvatar = $user->avatar;
 
         $avatarDir = FCPATH . (setting('Users.avatarDirectory') ?? 'uploads/avatars');

--- a/src/Users/Views/_avatar.php
+++ b/src/Users/Views/_avatar.php
@@ -4,7 +4,7 @@
     </div>
     <div class="col-12 mt-4">
         <?php if (!empty($user->avatar)) : ?>
-            <p class="small"><a href="<?= url_to('user-avatar-delete', $user->id) ?>" hx-get="<?= url_to('user-avatar-delete', $user->id) ?>" hx-target="#avatar-place"> Delete uploaded image</a>
+            <p class="small"><a href="<?= url_to('user-avatar-delete', $user->id) ?>" hx-confirm="Are you sure you wish to remove the image? It cannot be restored" hx-get="<?= url_to('user-avatar-delete', $user->id) ?>" hx-target="#avatar-place"> Delete uploaded image</a>
         <?php endif; ?>
         <input type="file" class="form-control btn-upload" name="avatar" accept="image/*" />
     </div>

--- a/src/Users/Views/_avatar.php
+++ b/src/Users/Views/_avatar.php
@@ -1,0 +1,11 @@
+<div class="row">
+    <div class="col-12 d-flex justify-content-center">
+        <?= isset($user) ? $user->renderAvatar(140) : (new \Bonfire\Users\User())->renderAvatar(140) ?>
+    </div>
+    <div class="col-12 mt-4">
+        <?php if (!empty($user->avatar)) : ?>
+            <p class="small"><a href="<?= url_to('user-avatar-delete', $user->id) ?>" hx-get="<?= url_to('user-avatar-delete', $user->id) ?>" hx-target="#avatar-place"> Delete uploaded image</a>
+        <?php endif; ?>
+        <input type="file" class="form-control btn-upload" name="avatar" accept="image/*" />
+    </div>
+</div>

--- a/src/Users/Views/form.php
+++ b/src/Users/Views/form.php
@@ -32,16 +32,9 @@
                 <legend>Basic Info</legend>
 
                 <div class="row">
-                    <div class="col-12 col-sm-3 d-flex align-items-top pt-3">
+                    <div id="avatar-place" class="col-12 col-sm-3 d-flex align-items-top pt-3">
                         <!-- Avatar preview and edit links -->
-                        <div class="row">
-                            <div class="col-12 d-flex justify-content-center">
-                                <?= isset($user) ? $user->renderAvatar(140) : (new \Bonfire\Users\User())->renderAvatar(140) ?>
-                            </div>
-                            <div class="col-12 mt-4">
-                                <input type="file" class="form-control btn-upload" name="avatar" accept="image/*" />
-                            </div>
-                        </div>
+                        <?= $this->include('\Bonfire\Users\Views\_avatar') ?>
                     </div>
                     <div class="col">
                         <div class="row">

--- a/src/Users/Views/user_settings.php
+++ b/src/Users/Views/user_settings.php
@@ -76,8 +76,6 @@
 
             </fieldset>
 
-            <hr>
-
             <fieldset x-data="{remember: <?= old('allowRemember', setting('Auth.sessionConfig')['allowRemembering']) ? 1 : 0 ?>}">
                 <legend>Login</legend>
 
@@ -135,8 +133,6 @@
                     </div>
                 </div>
             </fieldset>
-
-            <hr>
 
             <fieldset>
                 <legend>Passwords</legend>
@@ -250,13 +246,16 @@
 
 
 
-            <fieldset x-data="{useGravatar: <?= old('useGravatar', setting('Users.useGravatar')) ? true : false ?>}">
+            <fieldset x-data="{
+                        useGravatar: <?= old('useGravatar', setting('Users.useGravatar')) ? 'true' : 'false' ?>, 
+                        avatarResize: <?= old('avatarResize', setting('Users.avatarResize')) ? 'true' : 'false' ?>
+                        }">
                 <legend>Avatars</legend>
 
                 <!-- Name Basis -->
                 <div class="row mb-3">
                     <div class="col-12 col-sm-4">
-                        <label class="form-check-label" for="avatarNameBasis">Display initials based on:</label>
+                        <label class="form-label" for="avatarNameBasis">Display initials based on:</label>
                         <select name="avatarNameBasis" class="form-select">
                             <option value="name" <?= old('avatarNameBasis', setting('Users.avatarNameBasis')) === 'name' ? 'selected' : '' ?>>Full Name</option>
                             <option value="username" <?= old('avatarNameBasis', setting('Users.avatarNameBasis')) === 'username' ? 'selected' : '' ?>>Username</option>
@@ -277,7 +276,7 @@
                                    @change="useGravatar = ! useGravatar"
                                 <?php if (old('useGravatar', setting('Users.useGravatar'))) : ?> checked <?php endif ?>
                             >
-                            <label class="form-check-label" for="use-gravatar">
+                            <label class="form-check-label fw-bold" for="use-gravatar">
                                 Use Gravatar for avatars
                             </label>
                         </div>
@@ -289,7 +288,7 @@
                 </div>
 
                 <!-- Gravatar Default -->
-                <div class="row" x-show="useGravatar">
+                <div class="row mb-3" x-show="useGravatar">
                     <div class="col-12 col-sm-4">
                         <label for="gravatarDefault" class="form-label">Gravatar default style</label>
                         <select name="gravatarDefault" class="form-select">
@@ -309,9 +308,47 @@
                         </p>
                     </div>
                 </div>
-            </fieldset>
 
-            <br><hr>
+                <!-- Avatar downsize -->
+                <div class="row">
+                    <div class="col-12 col-sm-4">
+                        <div class="form-check">
+                            <input type="hidden" name="avatarResize" value="0">
+                            <input class="form-check-input" type="checkbox" name="avatarResize"
+                                   value="1" id="avatar-resize"
+                                   @change="avatarResize = ! avatarResize"
+                                <?php if (old('avatarResize', setting('Users.avatarResize'))) : ?> checked <?php endif ?>
+                            >
+                            <label class="form-check-label" for="avatar-resize">
+                                Downsize avatar on upload
+                            </label>
+                        </div>
+                    </div>
+                    <div class="col px-5">
+                        <p class="text-muted small">Should the user-uploaded avatar image be downsized?</p>
+                    </div>
+                </div>
+
+                <!-- Gravatar Default -->
+                <div class="row" x-show="avatarResize">
+                    <div class="col-12 col-sm-4">
+                        <label for="avatar-size" class="form-label">Avatar max dimensions</label>
+
+                        <div class="input-group">
+                            <span class="input-group-text" id="px-notation">px</span>
+                            <input placeholder="<?= setting('User.avatarSizeFloor') ?? 32 ?>" name="avatarSize" type="number" min="<?= setting('User.avatarSizeFloor') ?? 32 ?>" class="form-control" value="<?= old('avatarSize', setting('Users.avatarSize')) ?>" id="avatar-size">
+                        </div>
+                    </div>
+                    <div class="col px-5 pt-2">
+                        <p class="text-muted small">
+                            The smallest dimension should not be less than <?= setting('User.avatarSizeFloor') ?? 32 ?> px.
+                        </p>
+                    </div>
+                </div>
+
+            </div>
+
+            </fieldset>
 
             <div class="text-end px-5 py-3">
                 <input type="submit" value="Save Settings" class="btn btn-primary btn-lg">

--- a/tests/Users/AdminSettingsTest.php
+++ b/tests/Users/AdminSettingsTest.php
@@ -44,6 +44,8 @@ final class AdminSettingsTest extends TestCase
                 'rememberLength'        => 55,
                 'email2FA'              => 1,
                 'minimumPasswordLength' => 10,
+                'avatarResize'          => 1,
+                'avatarSize'            => 180,
                 'validators'            => [
                     'CodeIgniter\Shield\Authentication\Passwords\CompositionValidator',
                 ],


### PR DESCRIPTION
Changes to Users module avatar image functionality:

* use random string in avatar name, so the image names cannot be guessed ("1_dRe9IG.jpg" instead of "1_avatar.jpg") - a privacy feature
* add new config options related to avatar placement and manipulation
* add functionality to remove image without uploading a new one (via htmx ajax call)
* delete old image when new is uploaded (now it does not work when images are in different formats)
* Ensure avatars are deleted together with users (via users model beforeDelete event)

Resizing would make PHP GD extension a new requirement for Bonfire2 (I do not think that is ever an issue, but will need to be specified). In case I missed it and it is a possible issue, functionality could be hidden when GD extension is not detected.