### PR TITLE
Fix recycler view which would dublicate page

### DIFF
--- a/src/Recycler/Views/listResource.php
+++ b/src/Recycler/Views/listResource.php
@@ -60,21 +60,19 @@
                             <td><?= esc($item[$column] ?? '') ?></td>
                         <?php endforeach ?>
                             <td class="text-end">
-                                <div class="btn-group">
-                                    <a href="<?= url_to('recycler-restore', $currentAlias, $item['id']) ?>"
-                                    class="text-success" title="<?= lang('Recycler.restoreMsgTitle') ?>"
-                                    onclick="return confirm('<?= lang('Recycler.restoreMsgContent') ?>');"
-                                    >
-                                        <i class="fas fa-trash-restore"></i>
-                                    </a>
-                                    &nbsp;
-                                    <a href="<?= url_to('recycler-purge', $currentAlias, $item['id']) ?>"
-                                    class="text-danger" title="<?= lang('Recycler.purgeMsgTitle') ?>"
-                                    onclick="return confirm('<?= lang('Recycler.purgeMsgContent') ?>');"
-                                    >
-                                        <i class="fas fa-minus-circle"></i>
-                                    </a>
-                                </div>
+                                <a href="<?= url_to('recycler-restore', $currentAlias, $item['id']) ?>"
+                                class="text-success" title="<?= lang('Recycler.restoreMsgTitle') ?>"
+                                onclick="return confirm('<?= lang('Recycler.restoreMsgContent') ?>');"
+                                >
+                                    <i class="fas fa-trash-restore"></i>
+                                </a>
+                                &nbsp;
+                                <a href="<?= url_to('recycler-purge', $currentAlias, $item['id']) ?>"
+                                class="text-danger" title="<?= lang('Recycler.purgeMsgTitle') ?>"
+                                onclick="return confirm('<?= lang('Recycler.purgeMsgContent') ?>');"
+                                >
+                                    <i class="fas fa-minus-circle"></i>
+                                </a>
                             </td>
                         </tr>
                     <?php endforeach ?>

--- a/src/Recycler/Views/listResource.php
+++ b/src/Recycler/Views/listResource.php
@@ -9,7 +9,24 @@
         </div>
         <?php if (count($resources) > 1) : ?>
             <div class="col-auto">
-                <select name="r" class="form-select" hx-get="?" hx-target="#resource">
+            <select name="r" class="form-select" x-data="{
+                    getRequest(selectedValue) {
+                        const url = new URL(window.location.href);
+                        url.searchParams.set('r', selectedValue);
+                        fetch(url.toString()).then(response => {
+                            if (response.ok) {
+                                return response.text();
+                            }
+                            throw new Error('Network response was not ok.');
+                        }).then(html => {
+                            document.body.innerHTML = html; // Replace the whole page content
+                            window.history.pushState(null, null, url.toString()); // Update the URL
+                        }).catch(error => {
+                            console.error('Error fetching data:', error);
+                        });
+                    }
+                }" x-on:change="getRequest($event.target.value)"
+            >
                 <?php foreach ($resources as $alias => $details) : ?>
                     <option value="<?= strtolower($alias) ?>" <?= (strtolower($currentAlias) === strtolower($alias)) ? 'selected' : ''?>><?= $details['label'] ?></option>
                 <?php endforeach ?>
@@ -43,19 +60,21 @@
                             <td><?= esc($item[$column] ?? '') ?></td>
                         <?php endforeach ?>
                             <td class="text-end">
-                                <a href="<?= url_to('recycler-restore', $currentAlias, $item['id']) ?>"
-                                   class="text-success" title="<?= lang('Recycler.restoreMsgTitle') ?>"
-                                   onclick="return confirm('<?= lang('Recycler.restoreMsgContent') ?>');"
-                                >
-                                    <i class="fas fa-trash-restore"></i>
-                                </a>
-                                &nbsp;
-                                <a href="<?= url_to('recycler-purge', $currentAlias, $item['id']) ?>"
-                                   class="text-danger" title="<?= lang('Recycler.purgeMsgTitle') ?>"
-                                   onclick="return confirm('<?= lang('Recycler.purgeMsgContent') ?>');"
-                                >
-                                    <i class="fas fa-minus-circle"></i>
-                                </a>
+                                <div class="btn-group">
+                                    <a href="<?= url_to('recycler-restore', $currentAlias, $item['id']) ?>"
+                                    class="text-success" title="<?= lang('Recycler.restoreMsgTitle') ?>"
+                                    onclick="return confirm('<?= lang('Recycler.restoreMsgContent') ?>');"
+                                    >
+                                        <i class="fas fa-trash-restore"></i>
+                                    </a>
+                                    &nbsp;
+                                    <a href="<?= url_to('recycler-purge', $currentAlias, $item['id']) ?>"
+                                    class="text-danger" title="<?= lang('Recycler.purgeMsgTitle') ?>"
+                                    onclick="return confirm('<?= lang('Recycler.purgeMsgContent') ?>');"
+                                    >
+                                        <i class="fas fa-minus-circle"></i>
+                                    </a>
+                                </div>
                             </td>
                         </tr>
                     <?php endforeach ?>


### PR DESCRIPTION
In current code on changing selection in recycler page an ajax request is made which replaces only part of the page with a full page. The result is not always obvious, but it can be seen as this: 

![paveikslas](https://github.com/lonnieezell/Bonfire2/assets/2669306/0b3b7251-ee57-440f-8309-07f1eb2eb2cf)

The changes replaces the htmx-based code in select with alpine component (htmx would be great here, but would not be trivial to implement, since we currently need full page reload for alerts to work). The issued get request reloads whole page, also changing the url in browser properly. 