### PR TITLE
Fix select-all js error

### DIFF
--- a/themes/Admin/js/admin.js
+++ b/themes/Admin/js/admin.js
@@ -13,6 +13,12 @@ function toggleSelectAll(checkbox) {
     }
 }
 
-document.querySelector('.select-all').addEventListener('click', function (e) {
-    toggleSelectAll(e.target)
-})
+// Check if there is a .select-all element on the page
+const selectAllElement = document.querySelector('.select-all');
+
+// Attach the event listener only if the element exists
+if (selectAllElement) {
+    selectAllElement.addEventListener('click', function (e) {
+        toggleSelectAll(e.target);
+    });
+}


### PR DESCRIPTION
Current code is trying to set event listener on element .select-all even if it is not present in the page, thus firing errors in console. The change makes the event listener conditional on the presence of the element.