### PR TITLE
Mark superadmin and admin-created users active by default

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -243,6 +243,7 @@ class Install extends BaseCommand
             'first_name' => $firstName,
             'last_name'  => $lastName,
             'username'   => $username,
+            'active'     => 1,
         ]);
         $users->save($user);
 

--- a/src/Users/Controllers/UserController.php
+++ b/src/Users/Controllers/UserController.php
@@ -149,6 +149,11 @@ class UserController extends AdminController
         // Fill in basic details
         $user->fill($this->request->getPost());
 
+        // Mark the user active if it is created by admin
+        if ($userId === null) {
+            $user->active = 1;
+        }
+
         // Save basic details
         $users->save($user);
 


### PR DESCRIPTION
Original user and admin-created users should be marked active by default. 
Otherwise, if user self-registration/activation is enabled in site settings, the superadmin and admin-created users get permanently locked out as they are not counted as active.