### PR TITLE
Add Setting to Customize Title of Cookie Policy Document in Cookie Consent Form

### DIFF
--- a/src/Consent/Config/Consent.php
+++ b/src/Consent/Config/Consent.php
@@ -65,6 +65,16 @@ class Consent extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
+     * Cookie Policy Document Title
+     * --------------------------------------------------------------------------
+     *
+     * A title of the document that contains the cookie policy.
+     * For example, 'Privacy Policy' or 'Cookie Policy'.
+     */
+    public string $policyTitle = 'Cookie Policy';
+
+    /**
+     * --------------------------------------------------------------------------
      * Cookie Message
      * --------------------------------------------------------------------------
      *

--- a/src/Consent/Controllers/ConsentSettingsController.php
+++ b/src/Consent/Controllers/ConsentSettingsController.php
@@ -46,6 +46,7 @@ class ConsentSettingsController extends AdminController
             'requireConsent'  => 'permit_empty',
             'consentLength'   => 'required_with[requireConsent]|string',
             'policyUrl'       => 'required_with[requireConsent]|string',
+            'policyTitle'       => 'required_with[requireConsent]|string',
             'consentMessage'  => 'required_with[requireConsent]|string',
             'consents.*.name' => 'required_with[requireConsent]|string',
             'consents.*.desc' => 'required_with[requireConsent]|string',
@@ -58,6 +59,7 @@ class ConsentSettingsController extends AdminController
         setting('Consent.requireConsent', $this->request->getPost('requireConsent') ? true : false);
         setting('Consent.consentLength', $this->request->getPost('consentLength'));
         setting('Consent.policyUrl', $this->request->getPost('policyUrl'));
+        setting('Consent.policyTitle', $this->request->getPost('policyTitle'));
         setting('Consent.consentMessage', $this->request->getPost('consentMessage'));
         setting('Consent.consents', $this->request->getPost('consents'));
 

--- a/src/Consent/Filters/ConsentFilter.php
+++ b/src/Consent/Filters/ConsentFilter.php
@@ -71,7 +71,8 @@ class ConsentFilter implements FilterInterface
         $link = strpos('http', (string) $link) === 0
             ? $link
             : site_url($link);
-        $html = str_ireplace('{policy_url}', "<a href='{$link}' target='_blank'>Cookie policy</a>", $html);
+        $policyTitle = setting('Consent.policyTitle');
+        $html = str_ireplace('{policy_url}', "<a href='{$link}' target='_blank'>{$policyTitle}</a>", $html);
 
         $cssFile = setting('Consent.consentFormStyles');
         $jsFile  = setting('Consent.consentFormScripts');

--- a/src/Consent/Views/settings.php
+++ b/src/Consent/Views/settings.php
@@ -54,7 +54,19 @@
                         <p class="text-muted small pt-5">May be either a full or relative URL</p>
                     </div>
                 </div>
-
+                <!-- Cookie Policy Document Title-->
+                <div class="row mb-3">
+                    <div class="col-12 col-sm-6">
+                        <label class="form-label" for="policyTitle">Title of Cookie Policy document</label>
+                        <input type="text" class="form-control" name="policyTitle" value="<?= old('policyTitle', setting('Consent.policyTitle')) ?>">
+                        <?php if (has_error('policyTitle')) : ?>
+                            <p class="text-danger"><?= error('policyTitle') ?></p>
+                        <?php endif ?>
+                    </div>
+                    <div class="col">
+                        <p class="text-muted small pt-5">Will be shown in the Cookies Consent dialog instead of {policy_url}</p>
+                    </div>
+                </div>
                 <!-- Consent Message -->
                 <div class="row mb-3">
                     <div class="col-12 col-sm-6">
@@ -65,7 +77,7 @@
                         <?php endif ?>
                     </div>
                     <div class="col">
-                        <p class="text-muted small pt-5">May be either a full or relative URL. Will replace {policy_url} with the correct URL.</p>
+                        <p class="text-muted small pt-5">May be either a full or relative URL. Will replace {policy_url} with the correct URL and Cookie Policy document title</p>
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
This pull request introduces a new feature to customise the title of the document containing the _Cookie Policy_ in the Cookie Consent Form.

Purpose:
The addition of this feature allows users to tailor the title of the _Cookie Policy_ document to better suit their website's requirements. By providing this customisation option, we enhance the flexibility of the cookie consent form.

