### PR TITLE
Add more flexible asset attributes

### DIFF
--- a/src/Assets/Helpers/assets_helper.php
+++ b/src/Assets/Helpers/assets_helper.php
@@ -8,35 +8,53 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-if (! defined('asset_link')) {
+if (!defined('asset_link')) {
     /**
      * Generates the URL to serve an asset to the client
      *
+     * @param string $location url to asset file
      * @param string $type css, js
+     * @param mixed  $attributes Additional attributes to include in the asset link tag. 
+     *                           Can be provided as a string or an associative array of attribute-value pairs.
+     *                           Defaults to null if no additional attributes are needed.
      */
-    function asset_link(string $location, string $type, bool $preload=false): string
+    function asset_link(string $location, string $type, ?mixed $attributes = null): string
     {
         $url = asset($location, $type);
 
         $tag = '';
-        $relationString = $preload
-            ? 'rel="preload" as="' . ($type === 'css' ? 'style' : 'script') . '"'
-            : ($type === 'css' ? "rel='stylesheet'" : '');
+
+        $additionalAttr = '';
+        $defaultAttr = $type === 'css' ? "rel='stylesheet'" : "";
+
+        if (is_string($attributes)) {
+            $additionalAttr = $attributes;
+        }
+        if (is_array($attributes)) {
+            foreach ($attributes as $key => $value) {
+                if ($key === 'rel') {
+                    $defaultAttr = '';
+                }
+                $additionalAttr .= " $key='{$value}'";
+            }
+        }
+
+        $additionalAttr .= $defaultAttr;
 
         switch ($type) {
             case 'css':
-                $tag = "<link href='{$url}' {$relationString} />";
+                $tag = "<link href='{$url}' {$additionalAttr} />";
                 break;
 
             case 'js':
-                $tag = "<script src='{$url}' {$relationString}></script>";
+                $tag = "<script src='{$url}' {$additionalAttr}></script>";
         }
 
         return $tag;
     }
 }
 
-if (! defined('asset')) {
+if (!defined('asset')) {
     function asset(string $location, string $type): string
     {
         $config   = config('Assets');
@@ -78,7 +96,7 @@ if (! defined('asset')) {
 
             $filetime = filemtime($path);
 
-            if (! $filetime) {
+            if (!$filetime) {
                 throw new \RuntimeException('Unable to get modification time of asset file: ' . $filename);
             }
             $fingerprint = $separator . $filetime;

--- a/src/Assets/Helpers/assets_helper.php
+++ b/src/Assets/Helpers/assets_helper.php
@@ -14,8 +14,8 @@ if (!defined('asset_link')) {
      *
      * @param string $location   url to asset file
      * @param string $type       css, js
-     * @param mixed  $attributes Additional attributes to include in the asset link tag. 
-     *                           Can be provided as a string (for value-less attributes like "defer") 
+     * @param mixed  $attributes Additional attributes to include in the asset link tag.
+     *                           Can be provided as a string (for value-less attributes like "defer")
      *                           or an associative array of attribute-value pairs.
      *                           Defaults to null.
      */
@@ -26,7 +26,7 @@ if (!defined('asset_link')) {
         $tag = '';
 
         $additionalAttr = '';
-        $defaultAttr = $type === 'css' ? "rel='stylesheet'" : "";
+        $defaultAttr    = $type === 'css' ? "rel='stylesheet'" : '';
 
         if (is_string($attributes)) {
             $additionalAttr = $attributes;

--- a/src/Assets/Helpers/assets_helper.php
+++ b/src/Assets/Helpers/assets_helper.php
@@ -12,13 +12,14 @@ if (!defined('asset_link')) {
     /**
      * Generates the URL to serve an asset to the client
      *
-     * @param string $location url to asset file
-     * @param string $type css, js
+     * @param string $location   url to asset file
+     * @param string $type       css, js
      * @param mixed  $attributes Additional attributes to include in the asset link tag. 
-     *                           Can be provided as a string or an associative array of attribute-value pairs.
-     *                           Defaults to null if no additional attributes are needed.
+     *                           Can be provided as a string (for value-less attributes like "defer") 
+     *                           or an associative array of attribute-value pairs.
+     *                           Defaults to null.
      */
-    function asset_link(string $location, string $type, ?mixed $attributes = null): string
+    function asset_link(string $location, string $type, mixed $attributes = null): string
     {
         $url = asset($location, $type);
 
@@ -32,10 +33,11 @@ if (!defined('asset_link')) {
         }
         if (is_array($attributes)) {
             foreach ($attributes as $key => $value) {
+                // if the array already includes the 'rel', remove the default
                 if ($key === 'rel') {
                     $defaultAttr = '';
                 }
-                $additionalAttr .= " $key='{$value}'";
+                $additionalAttr .= "{$key}='{$value}' ";
             }
         }
 


### PR DESCRIPTION
Add third argument to helper asset_link function; if a string is passed, the string is interpreted as a value-less attribute; if an array is passed, they are formed into set of attribute="value" pairs. In case of css assets, if no rel attribute is provided, the default rel="stylesheet" is returned. 

review with care, for it is not compatible with [recently added](https://github.com/lonnieezell/Bonfire2/commit/64494f68c284ff42db53fff486c7dce4eff0c285) functionality, which is not in use within Bonfire2 but might be in use by someone using it. 