### PR TITLE
Prevent unauthorized user privileges

### DIFF
--- a/src/Users/Controllers/UserController.php
+++ b/src/Users/Controllers/UserController.php
@@ -165,7 +165,6 @@ class UserController extends AdminController
         // Check for an avatar to upload
         if ($file = $this->request->getFile('avatar')) {
             if ($file->isValid()) {
-
                 // Check if the avatar is to be resized
                 $avatarResize     = setting('Users.avatarResize') ?? false;
                 $maxDimension     = setting('Users.avatarSize') ?? 140;
@@ -225,12 +224,19 @@ class UserController extends AdminController
             // omit previously unset admin groups if user performing changes
             // should not manage admins
             if (! auth()->user()->can('users.manage-admins')) {
+                // prevent adding
                 foreach ($groups as $key => $group) {
                     if (
                         ! $user->inGroup($group)
-                        && in_array($group, ['admin','superadmin'])
+                        && in_array($group, ['admin', 'superadmin'], true)
                     ) {
                         unset($groups[$key]);
+                    }
+                }
+                // prevent removing: return any removed admin role
+                foreach ($user->getGroups() as $group) {
+                    if (in_array($group, ['admin', 'superadmin'], true) && ! in_array($group, $groups, true)) {
+                        $groups[] = $group;
                     }
                 }
             }

--- a/src/Users/Views/form.php
+++ b/src/Users/Views/form.php
@@ -94,7 +94,14 @@
                         <div class="form-group col-12 col-sm-6">
                             <select name="groups[]" multiple="multiple" class="form-control" <?php if (! auth()->user()->can('users.edit')) echo ' disabled' ?>>
                                 <?php foreach ($groups as $group => $info) : ?>
-                                    <option value="<?= $group ?>" <?php if (isset($user) && $user->inGroup($group)) : ?> selected <?php endif ?>>
+                                    <option value="<?= $group ?>"
+                                        <?php if (isset($user) && $user->inGroup($group)) : ?> selected <?php endif ?>
+                                        <?php if (
+                                            ! auth()->user()->can('users.manage-admins')
+                                            && in_array($group, ['admin','superadmin'])
+                                            && (isset($user) && ! $user->inGroup($group))
+                                            ) : ?> disabled <?php endif ?>
+                                    >
                                         <?= $info['title'] ?? $group ?>
                                     </option>
                                 <?php endforeach ?>

--- a/src/Users/Views/form.php
+++ b/src/Users/Views/form.php
@@ -85,7 +85,11 @@
                     <legend>Groups</legend>
 
                     <?php if (auth()->user()->can('users.edit')) : ?>
-                        <p>Select one or more groups for the user to belong to.</p>
+                        <p>Select one or more groups for the user to belong to.
+                        <?php if(! auth()->user()->can('users.manage-admins')) : ?>
+                            Groups with administrator privileges cannot be added or removed with your current permissions.
+                        <?php endif; ?>
+                        </p>
                     <?php else : ?>
                         <p>Groups that the user belongs to (you do not have permission to modify the list).</p>
                     <?php endif; ?>

--- a/src/Users/Views/permissions.php
+++ b/src/Users/Views/permissions.php
@@ -15,9 +15,13 @@
         <fieldset>
             <legend>User Permissions</legend>
 
-            <p>These permissions are applied in addition to any allowed by the user's groups.</p>
+            <p>These permissions are applied in addition to any allowed by the user's groups.
+                If you do not have the <em>users.manage-admins</em> permission, permissions
+                related to user management will not be selectable (unless they have been
+                granted previously).</p>
 
-            <p>Indeterminate checkboxes indicate the permission is already available from one or more groups the user is a part of.</p>
+            <p>Indeterminate checkboxes indicate the permission is already available from one or more groups the user is
+                a part of.</p>
             <div class="table-responsive">
                 <table class="table table-striped">
                     <thead>
@@ -28,19 +32,30 @@
                         </tr>
                     </thead>
                     <tbody>
-                    <?php foreach ($permissions as $permission => $description) : ?>
+                        <?php foreach ($permissions as $permission => $description) : ?>
                         <tr>
                             <td>
-                                <input class="form-check-input <?= $user->can($permission) ? 'in-group' : '' ?>" type="checkbox" name="permissions[]" value="<?= $permission ?>"
+                                <input
+                                    class="form-check-input <?= $user->can($permission) ? 'in-group' : '' ?>"
+                                    type="checkbox" name="permissions[]"
+                                    value="<?= $permission ?>"
                                     <?php if ($user->hasPermission($permission)) : ?>
-                                        checked
-                                    <?php endif ?>
+                                checked
+                                <?php endif ?>
+                                <?php if (
+                                    ! $user->hasPermission($permission)
+                                    && ! auth()->user()->can('users.manage-admins')
+                                    && explode('.', $permission)[0] === 'users'
+                                ) :
+                                    ?>
+                                disabled
+                                <?php endif ?>
                                 >
                             </td>
                             <td><?= $permission ?></td>
                             <td><?= $description ?></td>
                         </tr>
-                    <?php endforeach ?>
+                        <?php endforeach; ?>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
It should not be possible for an admin (without users.manage-admins permission) to manage other admins or superadmins (change their permissions, groups, etc.). This PR implements those safeguards at controller level and also at view level (so the unprivileged user is not given an incorrect impression of what he can do). The admin can still edit groups and permissions provided the ones he cannot manage have been set previously. 