### PR TITLE
Further improvements on admin management

### DIFF
--- a/src/Users/Views/form.php
+++ b/src/Users/Views/form.php
@@ -86,17 +86,23 @@
                 <div
                     x-data="{ isChecked: <?= $user->isBanned() ? 'true' : 'false' ?> }">
                     <input class="form-check-input" type="checkbox" name="activate" id="activate" value="1"
-                    <?php if (! $user->isNotActivated()) : ?>
-                        checked disabled
-                    <?php endif; ?>
+                        <?php if (! $user->isNotActivated()) : ?>
+                            checked disabled
+                        <?php endif; ?>
                     >
                     <label class="form-check-label" for="activate">
                         User is activated
                     </label><br>
                     <input type="hidden" name="ban" value="0">
                     <input class="form-check-input" type="checkbox" name="ban" id="ban" value="1" x-model="isChecked"
-                    <?php if ($itsMe) : ?>
-                        disabled
+                        <?php if (
+                            $itsMe
+                            || (
+                                ! auth()->user()->can('users.manage-admins')
+                                && $user->inGroup('admin', 'superadmin')
+                            )
+                        ) : ?>
+                    disabled
                     <?php endif; ?>
                     >
                     <label class="form-check-label" for="ban">
@@ -110,38 +116,41 @@
             </fieldset>
             <?php endif; ?>
 
-                <fieldset>
-                    <legend>Groups</legend>
+            <fieldset>
+                <legend>Groups</legend>
 
-                    <?php if (auth()->user()->can('users.edit')) : ?>
-                        <p>Select one or more groups for the user to belong to.
-                        <?php if(! auth()->user()->can('users.manage-admins')) : ?>
-                            Groups with administrator privileges cannot be added or removed with your current permissions.
-                        <?php endif; ?>
-                        </p>
-                    <?php else : ?>
-                        <p>Groups that the user belongs to (you do not have permission to modify the list).</p>
+                <?php if (auth()->user()->can('users.edit')) : ?>
+                <p>Select one or more groups for the user to belong to.
+                    <?php if(! auth()->user()->can('users.manage-admins')) : ?>
+                        Groups with administrator privileges cannot be added or removed with your current permissions.
                     <?php endif; ?>
+                </p>
+                <?php else : ?>
+                    <p>Groups that the user belongs to (you do not have permission to modify the list).</p>
+                <?php endif; ?>
 
-                    <div class="row">
-                        <div class="form-group col-12 col-sm-6">
-                            <select name="groups[]" multiple="multiple" class="form-control" <?php if (! auth()->user()->can('users.edit')) echo ' disabled' ?>>
-                                <?php foreach ($groups as $group => $info) : ?>
-                                    <option value="<?= $group ?>"
-                                        <?php if (isset($user) && $user->inGroup($group)) : ?> selected <?php endif ?>
-                                        <?php if (
-                                            ! auth()->user()->can('users.manage-admins')
-                                            && in_array($group, ['admin','superadmin'])
-                                            && (isset($user) && ! $user->inGroup($group))
-                                            ) : ?> disabled <?php endif ?>
+                <div class="row">
+                    <div class="form-group col-12 col-sm-6">
+                        <select name="groups[]" multiple="multiple" class="form-control"
+                            <?php if (! auth()->user()->can('users.edit')) {
+                                echo ' disabled';
+                            } ?>>
+                            <?php foreach ($groups as $group => $info) : ?>
+                                <option value="<?= $group ?>" <?php if (isset($user) && $user->inGroup($group)) : ?>
+                                    selected <?php endif ?>
+                                    <?php if (
+                                        ! auth()->user()->can('users.manage-admins')
+                                        && in_array($group, ['admin','superadmin'])
+                                    ) : ?> disabled
+                                    <?php endif ?>
                                     >
-                                        <?= $info['title'] ?? $group ?>
-                                    </option>
-                                <?php endforeach ?>
-                            </select>
-                        </div>
+                                    <?= $info['title'] ?? $group ?>
+                                </option>
+                            <?php endforeach ?>
+                        </select>
                     </div>
-                </fieldset>
+                </div>
+            </fieldset>
 
             <!-- User Meta Fields -->
             <div class="row">


### PR DESCRIPTION
a) Ensure admin without users.manage-admins permission cannot ban (super)admins 
b) When an admin edits other admin user without users.manage-admins permission, make the admin and superadmin groups disabled