### PR TITLE
improvements of style to forms (Users for now)

### DIFF
--- a/src/Users/Views/form.php
+++ b/src/Users/Views/form.php
@@ -28,7 +28,7 @@
                 <input type="hidden" name="id" value="<?= $user->id ?>">
             <?php endif ?>
 
-            <fieldset>
+            <fieldset class="first">
                 <legend>Basic Info</legend>
 
                 <div class="row">
@@ -153,9 +153,7 @@
             </fieldset>
 
             <!-- User Meta Fields -->
-            <div class="row">
                 <?= view_cell('\Bonfire\Users\Libraries\UserCells::metaFormFields') ?>
-            </div>
 
             <div class="text-end py-3">
                 <input type="submit" value="Save User" class="btn btn-primary btn-lg">

--- a/src/Users/Views/meta/list.php
+++ b/src/Users/Views/meta/list.php
@@ -1,6 +1,8 @@
 <?php if (isset($fieldGroups) && count($fieldGroups)) : ?>
     <?php foreach ($fieldGroups as $group => $fields) : ?>
         <fieldset>
+    <div class="row">
+        <div class="col">
             <legend><?= esc($group) ?></legend>
 
             <?php foreach ($fields as $field => $info) : ?>
@@ -36,6 +38,8 @@
                     </div>
                 <?php endif ?>
             <?php endforeach ?>
+        </div>
+    </div>
         </fieldset>
     <?php endforeach ?>
 <?php endif ?>

--- a/src/Users/Views/permissions.php
+++ b/src/Users/Views/permissions.php
@@ -12,7 +12,7 @@
     <form action="<?= current_url() ?>" method="post">
         <?= csrf_field() ?>
 
-        <fieldset>
+        <fieldset class="first">
             <legend>User Permissions</legend>
 
             <p>These permissions are applied in addition to any allowed by the user's groups.

--- a/src/Users/Views/security.php
+++ b/src/Users/Views/security.php
@@ -14,7 +14,7 @@
 
 <x-admin-box>
 
-    <fieldset>
+    <fieldset class="first">
 
         <legend>Change password</legend>
         <?= view('Bonfire\Users\Views\password_change', ['user' => $user ?? null]) ?>

--- a/src/Users/Views/user_settings.php
+++ b/src/Users/Views/user_settings.php
@@ -10,7 +10,7 @@
         <form action="<?= site_url(ADMIN_AREA . '/settings/users') ?>" method="post">
             <?= csrf_field() ?>
 
-            <fieldset>
+            <fieldset class="first">
                 <legend>Registration</legend>
 
                 <div class="row">

--- a/themes/Admin/css/admin.css
+++ b/themes/Admin/css/admin.css
@@ -293,9 +293,15 @@ label.form-label {
 }
 
 fieldset {
-    border-bottom: solid 1px var(--bf-light-grey);
-    padding-bottom: 2rem;
+    border-top: solid 1px var(--bf-light-grey);
+    padding-bottom: 1rem;
+    padding-top:0.5rem;
     margin-bottom: 1rem;
+}
+
+fieldset.first {
+    border-top: solid 0px;
+    padding-top: 0;
 }
 
 input[type="checkbox"]:indeterminate {
@@ -462,6 +468,7 @@ input[type="checkbox"]:indeterminate {
     align-items: center;
     justify-content: center;
 }
+
 /*
  * --------------------------------------------------------------------------
  * DASHBOARD
@@ -476,6 +483,7 @@ input[type="checkbox"]:indeterminate {
     display: inline-block;
     height: 100px;
 }
+
 .quick-link a {
     color: var(--bf-black);
     text-decoration: none;
@@ -489,10 +497,12 @@ input[type="checkbox"]:indeterminate {
     display: inline-block;
     opacity: 0.5;
 }
+
 .quick-link a:hover {
     opacity: 1.0;
-    box-shadow: 0 0 0.5rem rgba(0, 0, 0, .1) ;
+    box-shadow: 0 0 0.5rem rgba(0, 0, 0, .1);
 }
+
 .quick-link a i {
     display: block;
 }
@@ -509,9 +519,11 @@ input[type="checkbox"]:indeterminate {
     text-align: center;
     opacity: 0.7;
 }
+
 .alert-offline:hover {
     opacity: 1.0;
 }
+
 .main.offline {
     top: 37px;
 }


### PR DESCRIPTION
- discard line before save button
- move row/column formatting from main view to meta view (gives more uniform look)

This would make the forms look much cleaner. So far only User management and settings forms are corrected. 

If this change is approved, I will add likewise corrections for the other forms as well. This has to be done before the merge (as this change, without corresponding changes elsewhere, will add a line at the top of the form). 