### PR TITLE
Enable support in User Meta for text-like field types and textarea

### DIFF
--- a/docs/users_and_security/user_meta.md
+++ b/docs/users_and_security/user_meta.md
@@ -29,7 +29,7 @@ you can specify:
 - **label** is the label shown for the HTML input.
 
 - **type** is the type of HTML input. Currently most of the text-type inputs are supported (text, password, email, date, number, etc)
-    as well as textareas for when you need more information.
+    as well as checkboxes, and textareas for when you need more information.
 
 - **required** is a boolean about whether that field is required when editing a user.
 

--- a/src/Users/Config/Users.php
+++ b/src/Users/Config/Users.php
@@ -115,8 +115,8 @@ class Users extends BaseConfig
      * Each field can have the following values in it's options array:
      *  - label: the input label. If one is not provided, the field name will be used.
      *  - type: the type of HTML input used. Should be the simpler inputs,
-     *      like text, number, email, textarea, etc.
-     *      Selects, checkboxes, radios, etc are not supported.
+     *      like text, number, email, url, date, etc., as well as textarea, checkbox.
+     *      Selects, radios, etc are not supported.
      *  - required: true/false
      *  - validation: a validation rules string. If not present will be 'permit_empty|string'
      */

--- a/src/Users/Views/meta/list.php
+++ b/src/Users/Views/meta/list.php
@@ -5,7 +5,7 @@
 
             <?php foreach ($fields as $field => $info) : ?>
                 <?php if ($info['type'] === 'checkbox') : ?>
-                    <div class="form-check col-12 col-sm-6">
+                    <div class="form-check col-12 col-md-6">
                         <?php $metaValue = $user->meta(strtolower($field)) ?? 'false'; ?>
                         <input type="hidden" name="meta[<?= strtolower($field) ?>]" value="false">
                         <input type="checkbox" class="form-check-input" name="meta[<?= strtolower($field) ?>]"
@@ -18,18 +18,27 @@
                         <?php endif ?>
                     </div>
                 <?php elseif ($info['type'] === 'textarea') : ?>
-
-                <?php elseif ($info['type'] === 'number') : ?>
-
-                <?php else : ?>
-                    <div class="form-group col-12 col-sm-6">
+                    <div class="form-group col-12 col-lg-6">
                         <?php if (! isset($info['label'])) : ?>
                             <label for="meta[<?= $field ?>]" class="form-label"><?= esc(ucwords(strtolower(str_replace(['-', '_'], ' ', $field)))) ?></label>
                         <?php else : ?>
                             <label for="meta[<?= $field ?>]" class="form-label"><?= esc($info['label']) ?></label>
                         <?php endif ?>
-                        <input type="text" name="meta[<?= strtolower($field) ?>]" class="form-control" autocomplete="<?= strtolower($field) ?>"
-                               value="<?= old('meta[' . strtolower($field) . ']', $user->meta(strtolower($field)) ?? '') ?>">
+                        <textarea class="form-control" rows="3" name="meta[<?= strtolower($field) ?>]"
+                            ><?= old('meta[' . strtolower($field) . ']', $user->meta(strtolower($field)) ?? '') ?></textarea>
+                        <?php if (has_error('meta.' . $field)) : ?>
+                            <p class="text-danger"><?= error('meta.' . $field) ?></p>
+                        <?php endif ?>
+                    </div>
+                <?php elseif (in_array($info['type'], ['text', 'number', 'password', 'email', 'tel', 'url', 'date', 'time', 'week', 'month', 'color'])) : ?>
+                    <div class="form-group col-12 col-md-6">
+                        <?php if (! isset($info['label'])) : ?>
+                            <label for="meta[<?= $field ?>]" class="form-label"><?= esc(ucwords(strtolower(str_replace(['-', '_'], ' ', $field)))) ?></label>
+                        <?php else : ?>
+                            <label for="meta[<?= $field ?>]" class="form-label"><?= esc($info['label']) ?></label>
+                        <?php endif ?>
+                        <input type="<?= $info['type'] ?>" name="meta[<?= strtolower($field) ?>]" class="form-control" autocomplete="<?= strtolower($field) ?>"
+                            value="<?= old('meta[' . strtolower($field) . ']', $user->meta(strtolower($field)) ?? '') ?>">
                         <?php if (has_error('meta.' . $field)) : ?>
                             <p class="text-danger"><?= error('meta.' . $field) ?></p>
                         <?php endif ?>


### PR DESCRIPTION
Enable support in User Meta for text-like field types: number, password, email, tel, url, date, time, week, month, color 
Enable support for textarea;
Update documentation accordingly (+add info about previously added checkbox support)