### PR TITLE
Fixed Auth Config $views['layout'] value...

### DIFF
--- a/src/Auth/Config/Auth.php
+++ b/src/Auth/Config/Auth.php
@@ -37,7 +37,7 @@ class Auth extends ShieldAuth
      * --------------------------------------------------------------------
      */
     public array $views = [
-        'layout'                      => 'master',
+        'layout'                      => '\CodeIgniter\Shield\Views\layout',
         'email_layout'                => '\Bonfire\Views\email',
         'login'                       => '\Bonfire\Views\Auth\login',
         'register'                    => '\Bonfire\Views\Auth\register',


### PR DESCRIPTION
...to reference the appropriate Shield layout, instead of 'master'.

Same issue as #352 

Was getting an Invalid File error after login, on a fresh install, with 2FA enabled. Looks like the value should be the Shield view layout?
