### PR TITLE
remove 'required' key, explain how to add labels in validation messages

### DIFF
--- a/docs/users_and_security/user_meta.md
+++ b/docs/users_and_security/user_meta.md
@@ -9,15 +9,31 @@ modify that manually.
 ## Defining Meta Fields
 
 All fields are defined within `app/Config/Users.php`. Two fields are provided (though commented out) as examples.
+Additionally, if you need labels for fields in validation messages, or if you need custom validation messages,
+expand the $metaFields 'validation' value into multidimensional array of it's own, with keys
+`label` and `rules` like it is done with 'baz' value below (in case of custom error messages, you can add them
+in `errors` subarray, see
+[Validation in Codeigniter 4 documentation](https://codeigniter4.github.io/userguide/libraries/validation.html) 
+for more details).
 
 ```php
 public $metaFields = [
         'Example Fields' => [
-            'foo' => ['label' => 'Foo', 'type' => 'text', 'required' => true, 'validation' => 'permit_empty|string'],
-            'Bar' => ['type' => 'text', 'required' => true, 'validation' => 'required|string'],
+            'foo' => ['label' => 'Foo', 'type' => 'text', 'validation' => 'permit_empty|string'],
+            'Bar' => ['type' => 'text', 'validation' => 'required|string'],
+            'baz' => [
+                'label' => 'Baz',
+                'type' => 'checkbox',
+                'validation' => [
+                    'label' => 'Baz',
+                    'rules' => 'required|in_list[true,false]'
+                ],
+            ],
         ],
     ];
 ```
+
+
 
 Each major grouping within the `$metaFields` array specifies a fieldset legend name. This provides logical grouping
 of fields within the Edit User form.
@@ -26,14 +42,13 @@ Each entry within this fieldset is a single piece of information. The key is the
 field by later. Then each has an array of information that defines it. The array has the following options that
 you can specify:
 
-- **label** is the label shown for the HTML input.
+- **label** is the label shown for the HTML input (if **label** is within validation sub-array, it is displayed in validation messages).
 
 - **type** is the type of HTML input. Currently most of the text-type inputs are supported (text, password, email, date, number, etc)
     as well as checkboxes, and textareas for when you need more information.
 
-- **required** is a boolean about whether that field is required when editing a user.
-
-- **validation** is the set of validation rules that should be applied to this field when saving.
+- **validation** is the set of validation rules that should be applied to this field when saving, or a container for validation array of
+  a field (with optional `label`, `rules`, `errors` keys).
 
 ## Using Meta Info
 

--- a/src/Users/Config/Users.php
+++ b/src/Users/Config/Users.php
@@ -75,13 +75,13 @@ class Users extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
-     * Additional User Fields
+     * User Fields
      * --------------------------------------------------------------------------
      * Validation rules used when saving a user.
      */
     public $validation = [
         'id' => [
-            // Needed for the id in email test;
+            // Needed for the id in email and username validation (below);
             // see https://codeigniter4.github.io/userguide/installation/upgrade_435.html
             'rules' => 'permit_empty|is_natural_no_zero',
         ],
@@ -117,13 +117,23 @@ class Users extends BaseConfig
      *  - type: the type of HTML input used. Should be the simpler inputs,
      *      like text, number, email, url, date, etc., as well as textarea, checkbox.
      *      Selects, radios, etc are not supported.
-     *  - required: true/false
      *  - validation: a validation rules string. If not present will be 'permit_empty|string'
+     * NOTE: if you need labels for fields in validation messages, expand the 'validation'
+     * value into multidimensional array of it's own, with keys 'label' and 'rules',
+     * like it is done with 'baz' value below.
      */
     public $metaFields = [
         //        'Example Fields' => [
-        //            'foo' => ['label' => 'Foo', 'type' => 'text', 'required' => true, 'validation' => 'permit_empty|string'],
-        //            'Bar' => ['type' => 'text', 'required' => true, 'validation' => 'required|string'],
+        //            'foo' => ['label' => 'Foo', 'type' => 'text', 'validation' => 'permit_empty|string'],
+        //            'Bar' => ['type' => 'text', 'validation' => 'required|string'],
+        //            'baz' => [
+        //                 'label' => 'Baz',
+        //                 'type' => 'checkbox',
+        //                 'validation' => [
+        //                     'label' => 'Baz',
+        //                     'rules' => 'permit_empty|in_list[true,false]'
+        //                     ],
+        //                 ],
         //        ],
     ];
 }

--- a/src/Users/Config/Users.php
+++ b/src/Users/Config/Users.php
@@ -120,7 +120,7 @@ class Users extends BaseConfig
      *  - validation: a validation rules string. If not present will be 'permit_empty|string'
      * NOTE: if you need labels for fields in validation messages, expand the 'validation'
      * value into multidimensional array of it's own, with keys 'label' and 'rules',
-     * like it is done with 'baz' value below.
+     * like it is done with 'baz' value below (adding custom error messages is also possible here).
      */
     public $metaFields = [
         //        'Example Fields' => [
@@ -132,8 +132,8 @@ class Users extends BaseConfig
         //                 'validation' => [
         //                     'label' => 'Baz',
         //                     'rules' => 'permit_empty|in_list[true,false]'
-        //                     ],
         //                 ],
+        //             ],
         //        ],
     ];
 }


### PR DESCRIPTION
`required` key from $metaFields items is not used in the code and duplicates the validation rule `required`, so I removed it. 
Also, I added explanation in Users config file on how to get field labels (instead of placeholders) displayed in validation messages. 