### PR TITLE
Fix error when filtering by empty user group

### DIFF
--- a/src/Users/Models/UserFilter.php
+++ b/src/Users/Models/UserFilter.php
@@ -69,13 +69,10 @@ class UserFilter extends UserModel
         // two ways to go; if we have to search by groups, we have
         // to perform two queries instead of one to avoid duplicates
         if (isset($params['role']) && count($params['role'])) {
-            $secondQuery = true;
+            $this->distinct();
             $this->select('users.id');
             $this->join('auth_groups_users agu', 'agu.user_id = users.id')
                 ->whereIn('agu.group', $params['role']);
-        } else {
-            $secondQuery = false;
-            $this->select('users.*');
         }
 
         if (isset($params['active']) && count($params['active'])) {
@@ -101,19 +98,6 @@ class UserFilter extends UserModel
             $this->where('last_active', null);
         }
         // omitting 'where' for $params['last_active'] == 'all'
-
-        // if we need second query to avoid duplicates:
-        if ($secondQuery) {
-            $idList = $this->findAll();
-            $in     = [];
-
-            foreach ($idList as $v) {
-                $in[] = $v->id;
-            }
-            $nodup = array_unique($in);
-            $this->select('users.*');
-            $this->whereIn('id', $nodup);
-        }
 
         return $this;
     }

--- a/src/Users/Models/UserFilter.php
+++ b/src/Users/Models/UserFilter.php
@@ -66,11 +66,10 @@ class UserFilter extends UserModel
      */
     public function filter(?array $params = null)
     {
-        // two ways to go; if we have to search by groups, we have
-        // to perform two queries instead of one to avoid duplicates
+       
         if (isset($params['role']) && count($params['role'])) {
             $this->distinct();
-            $this->select('users.id');
+            $this->select('users.*');
             $this->join('auth_groups_users agu', 'agu.user_id = users.id')
                 ->whereIn('agu.group', $params['role']);
         }


### PR DESCRIPTION
Proposed fix for #446. 
The second query appears to be causing the issue, and a second query seems unnecessary to remove duplicates when we can use distinct or group by user id.