### PR TITLE
Log viewer fix

### DIFF
--- a/src/Common.php
+++ b/src/Common.php
@@ -48,12 +48,13 @@ if (! function_exists('app_date')) {
     {
         $format = $includeTime
             ? [
-                setting('App.dateFormat'),
-                setting('App.timeFormat'),
+                // values not by default in the Config\App, therefore need defaults
+                setting('App.dateFormat') ?? 'Y-m-d',
+                setting('App.timeFormat') ?? 'H:i:s',
                 $includeTimezone ? 'T' : '',
             ]
             : [
-                setting('App.dateFormat'),
+                setting('App.dateFormat') ?? 'Y-m-d',
                 $includeTimezone ? 'T' : '',
             ];
 

--- a/src/Tools/Controllers/LogsController.php
+++ b/src/Tools/Controllers/LogsController.php
@@ -20,7 +20,7 @@ class LogsController extends AdminController
     protected $theme      = 'Admin';
     protected $viewPrefix = 'Bonfire\Tools\Views\\';
     protected $logsPath   = WRITEPATH . 'logs/';
-    protected $ext = '.log';
+    protected $ext        = '.log';
     protected $logsLimit;
     protected $logsHandler;
 

--- a/src/Tools/Language/en/Tools.php
+++ b/src/Tools/Language/en/Tools.php
@@ -16,6 +16,7 @@ return [
     'empty'                 => 'No logs registered.',
     'level'                 => 'Level',
     'date'                  => 'Date',
+    'time'                  => 'Time',
     'file'                  => 'Filename',
     'content'               => 'Content',
     'deleteFile'            => 'Delete log file',

--- a/src/Tools/Language/it/Tools.php
+++ b/src/Tools/Language/it/Tools.php
@@ -16,6 +16,7 @@ return [
     'empty'                 => 'Nessun registro trovato.',
     'level'                 => 'Livello',
     'date'                  => 'Data',
+    'time'                  => 'Ora',
     'file'                  => 'Nome del file',
     'content'               => 'Contenuto',
     'deleteFile'            => 'Elimina il file di registro',

--- a/src/Tools/Language/lt/Tools.php
+++ b/src/Tools/Language/lt/Tools.php
@@ -16,6 +16,7 @@ return [
     'empty'                   => 'Žurnalų failų nėra.',
     'level'                   => 'Lygmuo',
     'date'                    => 'Data',
+    'time'                    => 'Laikas',
     'file'                    => 'Failo pavadinimas',
     'content'                 => 'Turinys',
     'deleteFile'              => 'Trinti žurnalo failą',

--- a/src/Tools/Views/view_log.php
+++ b/src/Tools/Views/view_log.php
@@ -5,7 +5,7 @@ $this->extend('master') ?>
 $this->section('main') ?>
 <x-page-head>
     <a href="<?= site_url(ADMIN_AREA . '/tools/logs') ?>" class="back">&larr; <?= lang('Tools.logsModTitle')?></a>
-    <h2><?= lang('Tools.log') ?> : <?= $logFilePretty ?></h2>
+    <h2><?= lang('Tools.log') ?>: <?= $logFilePretty ?></h2>
 </x-page-head>
 
 <x-admin-box>
@@ -14,7 +14,7 @@ $this->section('main') ?>
         <table class="table table-hover nowrap" id="log">
             <tr>
                 <th><?= lang('Tools.level'); ?></th>
-                <th><?= lang('Tools.date'); ?></th>
+                <th><?= lang('Tools.time'); ?></th>
                 <th><?= lang('Tools.content'); ?></th>
 
             </tr>
@@ -26,7 +26,7 @@ $this->section('main') ?>
                     <?php endif ?>
                 >
                     <td class="text-<?= $log['class']; ?>">
-                        <span class="<?= $log['icon']; ?>" aria-hidden="true"></span>&nbsp;<?= $log['level'] ?>
+                        <span class="<?= $log['icon']; ?> d-inline" aria-hidden="true"></span>&nbsp;<span class="d-inline"><?= $log['level'] ?></span>
                     </td>
                     <td class="date"><?= app_date($log['date'], true) ?></td>
                     <td class="text">

--- a/tests/Tools/LogsTest.php
+++ b/tests/Tools/LogsTest.php
@@ -38,7 +38,7 @@ final class LogsTest extends TestCase
             ->get(ADMIN_AREA . '/tools/view-log/' . str_replace('.log', '', $this->logFileName));
 
         $response->assertOK();
-        $response->assertSee(lang('Tools.log') . ' : '
+        $response->assertSee(lang('Tools.log') . ': '
             . app_date(str_replace('.log', '', str_replace('log-', '', $this->logFileName))));
     }
 


### PR DESCRIPTION
Log viewer could be broken because of site_date() function omitting default values. Some minor improvements added.