### PR TITLE
Workaround for breaking tests (temporary downgrade of CI4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
-    "codeigniter4/framework": "^4.4",
+    "codeigniter4/framework": "4.4|4.5.0 - 4.5.5|>4.5.7",
     "components/font-awesome": "^6.2",
     "codeigniter4/shield": "^1.0",
     "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
This is a temporary workaround regarding bug #483, avoiding CI4 versions 4.5.6-7, that break phpunit tests on PHP 8.1 (and other versions)