### PR TITLE
Update automatic tests on Github

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Drop PHP8.0 (not supported and little used), add tests for 8.3; 

Keep PHP 7.4 as legacy version still in active use.

see https://stitcher.io/blog/php-version-stats-july-2024