### PR TITLE
Changes to make phpunit tests run in Github actions (some temporary)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php-versions: ['7.4', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
-    "codeigniter4/framework": "^4.4",
+    "codeigniter4/framework": "4.4|4.5.0 - 4.5.5|>4.5.7",
     "components/font-awesome": "^6.2",
     "codeigniter4/shield": "^1.0",
     "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
This patch combines the pull requests #485 and #484, since individually they both fail the tests. Also (at least until a workaround is found) dropping php7.4 tests (no longer supported by current CI4.5.* versions)