### PR TITLE
Fix controlled component class name guessing, fix processing of self-closing component attributes

### DIFF
--- a/docs/building_sites/components.md
+++ b/docs/building_sites/components.md
@@ -44,7 +44,7 @@ in the following output:
 /> 
 ```
 
-## Custom Tags
+## Tags With Content
 
 You can include the content within the opening and closing tags by inserting the reserved `$slot` variable: 
 
@@ -61,10 +61,14 @@ You can include the content within the opening and closing tags by inserting the
 
 ## Controlled Components
 
-Finally, you can create a class to add additional logic to the output. The file must be in the same directory
-as the component view, and should have a name that is the PascalCase version of the filename, with 'Component'
-added to the end of it. 
+Finally, you can create a class to add additional logic to the output for both self-closing tags and tags 
+with content. The file must be in the same directory as the component view, and should have a name that is
+the PascalCase version of the filename, with 'Component' added to the end of it. Any attributes that you 
+set on the custom element and any content within element will be passed to the class of the controlled 
+component to be, optionally, processed by the component class and/or rendered by the comonent view file. 
+The data you pass will be available within the class as it's `$data` property (the tag content – as 
+`$data['slot']` property). 
 
 A `famous-qoutes` component would have a view called `famous-quotes.php` and a controlling class called
-`FamousQuotesComponent.php`. The class must extend `Bonfire\View\Component`. The only requirement is that you 
-implment a method called `render()`. 
+`FamousQuotesComponent.php`. The class must extend `Bonfire\View\Component`. The only requirement is that you
+implement a method called `render()`.

--- a/src/View/ComponentRenderer.php
+++ b/src/View/ComponentRenderer.php
@@ -183,7 +183,7 @@ class ComponentRenderer
     private function factory(string $name, string $view): ?Component
     {
         // Locate the class in the same folder as the view
-        $class    = pascalize($name) . 'Component.php';
+        $class    = pascalize(str_replace('-', '_', $name)) . 'Component.php';
         $filePath = str_replace($name . '.php', $class, $view);
 
         if (empty($filePath)) {

--- a/src/View/ComponentRenderer.php
+++ b/src/View/ComponentRenderer.php
@@ -95,7 +95,7 @@ class ComponentRenderer
             $component  = $this->factory($match['name'], $view);
 
             return $component instanceof Component
-                ? $component->withView($view)->render()
+                ? $component->withView($view)->withData($attributes)->render()
                 : $this->renderView($view, $attributes);
         }, $output);
     }


### PR DESCRIPTION
The `component-name.php` file names were not properly pascalized when guessing the controlled component class names (since `pascalize()` does not actually affect dashes, only spaces and underscores). Therefore this fix. Example app code at PR #482 depends on this fix, as it now includes an example controlled component.