### PR TITLE
Fix duplication of data in case more than one section of metadata is set

### DIFF
--- a/src/Core/Traits/HasMeta.php
+++ b/src/Core/Traits/HasMeta.php
@@ -185,10 +185,6 @@ trait HasMeta
         $this->hydrateMeta();
         helper('setting');
 
-        $inserts = [];
-        $updates = [];
-        $deletes = [];
-
         $metaInfo = setting("{$this->configClass}.metaFields");
         if (empty($metaInfo)) {
             return;
@@ -198,6 +194,10 @@ trait HasMeta
             if (! is_array($fields) || $fields === []) {
                 continue;
             }
+
+            $inserts = [];
+            $updates = [];
+            $deletes = [];
 
             foreach ($fields as $field => $info) {
                 $field    = strtolower($field);


### PR DESCRIPTION
Since the data was not reset on each iteration when executing the loop, it would get duplicated if there were more than one metadata section.