### PR TITLE
Fix index file removal (index.html not necessarily first one)

### DIFF
--- a/src/Tools/Controllers/LogsController.php
+++ b/src/Tools/Controllers/LogsController.php
@@ -41,7 +41,12 @@ class LogsController extends AdminController
         // Load the Log Files.
         $logs = get_filenames($this->logsPath);
 
-        unset($logs[0]);
+        // Define the regular expression pattern for log files
+        $logPattern = '/^log-\d{4}-\d{2}-\d{2}\.log$/';
+        // Filter the array removing index.html and other files that do not match
+        $logs = array_filter($logs, function ($filename) use ($logPattern) {
+            return preg_match($logPattern, $filename);
+        });
 
         $result = $this->logsHandler->paginateLogs($logs, $this->logsLimit);
 


### PR DESCRIPTION
The code now removes from log array all files that do not match the log file naming pattern. This not only removes index.html, but also other files (like renamed log files, that could otherwise cause exception).