### PR TITLE
fix: migrations during tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
-    "codeigniter4/framework": "4.4|4.5.0 - 4.5.5|>4.5.7",
+    "codeigniter4/framework": "^4.4",
     "components/font-awesome": "^6.2",
     "codeigniter4/shield": "^1.0",
     "roave/security-advisories": "dev-latest",

--- a/tests/_support/TestCase.php
+++ b/tests/_support/TestCase.php
@@ -28,7 +28,7 @@ abstract class TestCase extends CIUnitTestCase
      * When migrations are ran, will ensure
      * all migrations in all modules will run.
      */
-    protected $namespace = '';
+    protected $namespace = null;
 
     /**
      * @var Factory


### PR DESCRIPTION
This PR fixes migration issues when running tests with the latest CI4 releases.

Fixes #483

A side note - I would consider upgrading the versions in `composer.json` to `^4.5` and PHP `^8.1` - as these are only officially supported versions.