### PR TITLE
Feature/breaking changes notify

### DIFF
--- a/docs/intro/changelog.md
+++ b/docs/intro/changelog.md
@@ -2,6 +2,25 @@
 
 This holds the change history for Bonfire as we lead up to a 1.0 release. It's not exhaustive, but should give you a good idea of the changes that have been made and how it might impact you.
 
+IMPORTANT! *Breaking changes* are marked with words `breaking change` in parentheses right after the date.
+
+## 16 January 2024
+
+Bonfire can henceforth warn you about breaking changes (like need to update Admin/Auth themes, change config files, etc).
+
+To get such notifications when updating Bonfire, you can add a command to your
+composer.json scripts section:
+
+```json
+    "scripts": {
+        "post-update-cmd": [
+            "php spark notify:breaking-changes"
+        ]
+    }
+```
+
+New Bonfire install will automatically include this command.
+
 ## 18 March 2024 (breaking change)
 
 **<x-button\>** and **<x-button-container\>** view [components](https://github.com/lonnieezell/Bonfire2/blob/develop/docs/building_admin_modules/view_components.md) implemented.

--- a/src/Commands/BreakingChangesNotification.php
+++ b/src/Commands/BreakingChangesNotification.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Bonfire\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+
+class BreakingChangesNotification extends BaseCommand
+{
+    protected $group       = 'Bonfire';
+    protected $name        = 'notify:breaking-changes';
+    protected $description = 'Notifies about breaking changes after composer update.';
+
+    public function run(array $params)
+    {
+        $lastUpdateFile = BFPATH . 'last-update.txt';
+        $changelogFile = BFPATH . 'docs/intro/changelog.md';
+
+        // Read the last update date
+        $lastUpdateDate = $this->getLastUpdateDate($lastUpdateFile);
+
+        // Read the changelog file
+        $breakingChangeDate = $this->getLatestBreakingChangeDate($changelogFile);
+
+        if ($breakingChangeDate && (!$lastUpdateDate || $lastUpdateDate < $breakingChangeDate)) {
+            CLI::write('Warning: Breaking changes detected. Please read the changelog for more information.', 'yellow');
+            CLI::write('Breaking change date: ' . $breakingChangeDate, 'yellow');
+
+            // Update the last update date
+            file_put_contents($lastUpdateFile, $breakingChangeDate);
+        } else {
+            CLI::write('No new breaking changes detected.', 'green');
+        }
+    }
+
+    private function getLastUpdateDate(string $filePath): ?string
+    {
+        if (file_exists($filePath)) {
+            return trim(file_get_contents($filePath));
+        }
+
+        return null;
+    }
+
+    private function getLatestBreakingChangeDate(string $filePath): ?string
+    {
+        if (!file_exists($filePath)) {
+            return null;
+        }
+
+        $file = fopen($filePath, 'r');
+        if ($file) {
+            while (($line = fgets($file)) !== false) {
+                if (strpos($line, '(breaking change)') !== false) {
+                    preg_match('/## (\d{1,2} \w+ \d{4})/', $line, $matches);
+                    if (isset($matches[1])) {
+                        fclose($file);
+                        return date('Y-m-d', strtotime($matches[1]));
+                    }
+                }
+            }
+            fclose($file);
+        }
+
+        return null;
+    }
+}

--- a/src/Commands/BreakingChangesNotification.php
+++ b/src/Commands/BreakingChangesNotification.php
@@ -13,8 +13,8 @@ class BreakingChangesNotification extends BaseCommand
 
     public function run(array $params)
     {
-        $lastUpdateFile = BFPATH . 'last-update.txt';
-        $changelogFile = BFPATH . 'docs/intro/changelog.md';
+        $lastUpdateFile = BFPATH . '../last-update.txt';
+        $changelogFile  = BFPATH . '../docs/intro/changelog.md';
 
         // Read the last update date
         $lastUpdateDate = $this->getLastUpdateDate($lastUpdateFile);
@@ -23,13 +23,19 @@ class BreakingChangesNotification extends BaseCommand
         $breakingChangeDate = $this->getLatestBreakingChangeDate($changelogFile);
 
         if ($breakingChangeDate && (!$lastUpdateDate || $lastUpdateDate < $breakingChangeDate)) {
-            CLI::write('Warning: Breaking changes detected. Please read the changelog for more information.', 'yellow');
-            CLI::write('Breaking change date: ' . $breakingChangeDate, 'yellow');
+            CLI::write(
+                '======= WARNING: =======' . PHP_EOL .
+                'Breaking changes since the previous update of your Bonfire install detected. ' . PHP_EOL .
+                'You may need to update your app manually. ' . PHP_EOL .
+                'Please read the docs/intro/changelog.md file for more information.',
+                'yellow'
+            );
+            CLI::write('Latest breaking change date: ' . $breakingChangeDate, 'yellow');
 
-            // Update the last update date
-            file_put_contents($lastUpdateFile, $breakingChangeDate);
+            // Write new last update date
+            file_put_contents($lastUpdateFile, date('Y-m-d'));
         } else {
-            CLI::write('No new breaking changes detected.', 'green');
+            CLI::write('No new breaking changes in Bonfire detected since previous update.', 'green');
         }
     }
 
@@ -39,6 +45,8 @@ class BreakingChangesNotification extends BaseCommand
             return trim(file_get_contents($filePath));
         }
 
+        // Create the file if it does not exist
+        file_put_contents($filePath, '');
         return null;
     }
 


### PR DESCRIPTION
Add feature of warning about Bonfire's breaking changes. The added script checks for notices in the changelog about breaking changes since last app update and warns the user if breaking changes notification is found. 

On new projects this functionality would be autoinstalled; existing projects would have to add a command to composer.json manually. 