### PR TITLE
Change regexp to better deal with component-within-component situations

### DIFF
--- a/src/View/ComponentRenderer.php
+++ b/src/View/ComponentRenderer.php
@@ -111,11 +111,11 @@ class ComponentRenderer
                             )
                     /uismx';
 
-    /*
-        $match['name']       = tag name (minus the `x-`)
-        $match['attributes'] = string of tag attributes (class="foo")
-        $match['slot']       = the content inside the tags
-    */
+        /*
+            $match['name']       = tag name (minus the `x-`)
+            $match['attributes'] = string of tag attributes (class="foo")
+            $match['slot']       = the content inside the tags
+        */
 
         do {
             try {


### PR DESCRIPTION
Fix for occasional failure to render component within component.

I used here a solution proposed by @Zoly [here](https://github.com/lonnieezell/Bonfire2/issues/464#issuecomment-2253990338). It seems to work on all of my components.