### PR TITLE
fix: register namespace on CLI

### DIFF
--- a/src/Config/Events.php
+++ b/src/Config/Events.php
@@ -11,3 +11,7 @@ use CodeIgniter\Events\Events;
 Events::on('pre_system', static function (): void {
     Namespaces::register();
 });
+
+Events::on('pre_command', static function (): void {
+    Namespaces::register();
+});


### PR DESCRIPTION
This PR fixes the availability of all migrations under the CLI.

Without it, the migrations in the `Bonfire` namespace are not visible when running commands.