### PR TITLE
Fix missing update:composer-json error

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -122,7 +122,7 @@ class Install extends BaseCommand
             $this->createUser();
         }
 
-        $this->call('update:composer-json');
+        $this->updateComposerJson();
 
         CLI::newLine();
     }


### PR DESCRIPTION
I left this unchanged by accident, was at first working on a mechanism to update composer.json via a separate spark command.