### PR TITLE
Tests for language files

### DIFF
--- a/tests/Language/TranslationTest.php
+++ b/tests/Language/TranslationTest.php
@@ -6,7 +6,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 class TranslationTest extends CIUnitTestCase
 {
-    protected $englishFiles = [];
+    protected $englishFiles  = [];
     protected $languageFiles = [];
 
     protected function setUp(): void
@@ -18,7 +18,7 @@ class TranslationTest extends CIUnitTestCase
 
         // Get all language files for the main app
         foreach (glob($languageDir . '/*/Bonfire.php') as $file) {
-            $lang = basename(dirname($file));
+            $lang                                    = basename(dirname($file));
             $this->languageFiles['Bonfire'][$lang][] = $file;
 
             if ($lang === 'en') {
@@ -57,8 +57,8 @@ class TranslationTest extends CIUnitTestCase
 
             if (is_dir($languageDir)) {
                 foreach (glob($languageDir . '/*/*.php') as $file) {
-                    $lang = basename(dirname($file));
-                    $module = basename($dir);
+                    $lang                                  = basename(dirname($file));
+                    $module                                = basename($dir);
                     $this->languageFiles[$module][$lang][] = $file;
 
                     if ($lang === 'en') {
@@ -85,7 +85,7 @@ class TranslationTest extends CIUnitTestCase
     public function testLanguageFilesHaveSameKeysAsEnglish()
     {
         $allMissingKeys = [];
-        $allExtraKeys = [];
+        $allExtraKeys   = [];
 
         foreach ($this->englishFiles as $module => $englishFile) {
             if (!is_string($englishFile) || !file_exists($englishFile)) {
@@ -110,7 +110,7 @@ class TranslationTest extends CIUnitTestCase
                 $translations = $this->includeTodoTranslations($files[0], $translations);
 
                 $missingKeys = array_diff_key($englishTranslations, $translations);
-                $extraKeys = array_diff_key($translations, $englishTranslations);
+                $extraKeys   = array_diff_key($translations, $englishTranslations);
 
                 if (!empty($missingKeys)) {
                     $allMissingKeys[] = "Module '$module' in language '$lang': The file {$files[0]} is missing keys: " . implode(', ', array_keys($missingKeys)) . PHP_EOL . ' You may run "composer lang-update" to initiate missing keys' ;

--- a/tests/Language/TranslationTest.php
+++ b/tests/Language/TranslationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Language;
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+class TranslationTest extends CIUnitTestCase
+{
+    protected $englishFiles = [];
+    protected $languageFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Path to the language directory
+        $languageDir = BFPATH . 'Language';
+
+        // Get all language files for the main app
+        foreach (glob($languageDir . '/*/Bonfire.php') as $file) {
+            $lang = basename(dirname($file));
+            $this->languageFiles['Bonfire'][$lang][] = $file;
+
+            if ($lang === 'en') {
+                $this->englishFiles['Bonfire'] = $file;
+            }
+        }
+
+        // Discover core modules and their language files
+        $this->getCoreModulesLangFiles();
+    }
+
+    private function getCoreModulesLangFiles()
+    {
+        $modules = [];
+        // TODO: only include modules with Language directory, no excludes
+        $excluded = ['Core', 'Config', 'Language', 'Views'];
+
+        $map = directory_map(BFPATH, 1);
+
+        foreach ($map as $row) {
+            if (substr($row, -1) !== DIRECTORY_SEPARATOR) {
+                continue;
+            }
+
+            $name = trim($row, DIRECTORY_SEPARATOR);
+            if (in_array($name, $excluded, true)) {
+                continue;
+            }
+
+            $modules["Bonfire\\{$name}"] = BFPATH . "{$name}";
+        }
+
+        // Get language files for each module
+        foreach ($modules as $dir) {
+            $languageDir = $dir . '/Language';
+
+            if (is_dir($languageDir)) {
+                foreach (glob($languageDir . '/*/*.php') as $file) {
+                    $lang = basename(dirname($file));
+                    $module = basename($dir);
+                    $this->languageFiles[$module][$lang][] = $file;
+
+                    if ($lang === 'en') {
+                        $this->englishFiles[$module] = $file;
+                    }
+                }
+                //return;
+            }
+        }
+    }
+
+    public function testLanguageFilesReturnValidArray()
+    {
+        foreach ($this->languageFiles as $languages) {
+            foreach ($languages as $files) {
+                foreach ($files as $file) {
+                    $translations = include $file;
+                    $this->assertIsArray($translations, "The file $file does not return a valid array.");
+                }
+            }
+        }
+    }
+
+    public function testLanguageFilesHaveSameKeysAsEnglish()
+    {
+        $allMissingKeys = [];
+        $allExtraKeys = [];
+
+        foreach ($this->englishFiles as $module => $englishFile) {
+            if (!is_string($englishFile) || !file_exists($englishFile)) {
+                $this->fail("English language file for module '$module' does not exist or is not a valid file path: $englishFile");
+            }
+
+            $englishTranslations = include $englishFile;
+            if (!is_array($englishTranslations)) {
+                $this->fail("English language file for module '$module' does not return a valid array: $englishFile");
+            }
+
+            foreach ($this->languageFiles[$module] as $lang => $files) {
+                if (!isset($files[0]) || !is_string($files[0]) || !file_exists($files[0])) {
+                    $this->fail("Missing or invalid language file for module '$module' in language '$lang'.");
+                }
+
+                $translations = include $files[0];
+                if (!is_array($translations)) {
+                    $this->fail("Language file for module '$module' in language '$lang' does not return a valid array: {$files[0]}");
+                }
+
+                $translations = $this->includeTodoTranslations($files[0], $translations);
+
+                $missingKeys = array_diff_key($englishTranslations, $translations);
+                $extraKeys = array_diff_key($translations, $englishTranslations);
+
+                if (!empty($missingKeys)) {
+                    $allMissingKeys[] = "Module '$module' in language '$lang': The file {$files[0]} is missing keys: " . implode(', ', array_keys($missingKeys)) . PHP_EOL . ' You may run "composer lang-update" to initiate missing keys' ;
+                }
+
+                if (!empty($extraKeys)) {
+                    $allExtraKeys[] = "Module '$module' in language '$lang': The file {$files[0]} has extra keys: " . implode(', ', array_keys($extraKeys));
+                }
+            }
+        }
+
+        if (!empty($allMissingKeys)) {
+            $this->fail(implode("\n", $allMissingKeys));
+        }
+
+        if (!empty($allExtraKeys)) {
+            $this->fail(implode("\n", $allExtraKeys));
+        }
+    }
+
+    private function includeTodoTranslations($file, $translations)
+    {
+        $content = file_get_contents($file);
+        preg_match_all("/\/\/\s*'([^']+)'\s*=>\s*'([^']+)',\s*\/\/\s*TODO:\s*please\s*translate/", $content, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $translations[$match[1]] = $match[2];
+        }
+
+        return $translations;
+    }
+}


### PR DESCRIPTION
Tests for missing language files (taking the list of languages in `src/Language` as reference), missing keys in language files compared to the English lang files. Accepts commented out strings as ok (so, if English lang file has lines 

`   'someKey' => 'Some Key value', `

and the other language has: 
`  // 'someKey' => 'Some Key value', // TODO: please translate`

the test passes. 

Has shortcomings (only shows one problem at a time).

Would appreciate review.