### PR TITLE
Don't throw runtime error on missing assets

### DIFF
--- a/src/Assets/Helpers/assets_helper.php
+++ b/src/Assets/Helpers/assets_helper.php
@@ -100,6 +100,7 @@ if (!defined('asset')) {
         if (! file_exists($path)) { // Possible case of missing asset
 
             $fingerprint = $separator . 'asset-is-missing';
+            log_message('warning', 'Missing asset: ' . $path);
 
         } elseif ($config->bustingType === 'version') { // Asset version-based cache-busting
 

--- a/tests/Assets/AssetHelperTest.php
+++ b/tests/Assets/AssetHelperTest.php
@@ -39,11 +39,10 @@ final class AssetHelperTest extends TestCase
         asset_link('foo', 'css');
     }
 
-    public function testAssetThrowsNoFilename(): void
+    public function testAssetLinkContainsMissingSubstring()
     {
-        $this->expectException(RuntimeException::class);
-
-        asset_link('/admin/css/admin_missing.css', 'css');
+        $result = asset_link('/admin/css/admin_missing.css', 'css');
+        $this->assertStringContainsString('asset-is-missing', $result);
     }
 
     public function testAssetThrowsEmptyLocation(): void


### PR DESCRIPTION
Missing assets currently terminate page execution in runtime exception. Since asset is external file, it being missing should not be the cause of breaking the page itself. 

With these changes, when a missing asset is encountered, a string with a missing asset notice is produced, like: 
 https://example.com/assets/admin/js/tinymce6-ru~~asset-is-missing.js

This PR closes issue #538