### PR TITLE
Increase consent popup z-index to display above Bootstrap5 navbar

### DIFF
--- a/src/Consent/Views/consent_styles.php
+++ b/src/Consent/Views/consent_styles.php
@@ -9,7 +9,7 @@
         background-color: cadetblue;
         border: 1px solid lightgray;
         padding:20px;
-        z-index:2;
+        z-index:2000;
         font-size: 0.85rem;
         line-height: 1.2;
     }


### PR DESCRIPTION
Bootstrap5 navbar (likely to be used in the app) has z-index of 1020; consent popup should definitely be above navbars. 