### PR TITLE
Fixes and updates for HasMeta trait

### DIFF
--- a/docs/users_and_security/user_meta.md
+++ b/docs/users_and_security/user_meta.md
@@ -111,6 +111,14 @@ Deletes a single meta value from the user. This is immediately deleted. There is
 $user->deleteMeta('website_url');
 ```
 
+**deleteResourceMeta()**
+
+Deletes all meta info associated with an entity. To be used when purging a record.
+
+```php
+$user->deletResouceMeta();
+```
+
 **syncMeta(array $post)**
 
 Given an array of key/value pairs representing the name of the meta field and it's value, this will update existing
@@ -124,6 +132,10 @@ $post = [
 ];
 $user->syncMeta($post);
 ```
+
+`syncMeta()` will also delete meta data for the resource that is present in `meta_info` but not
+present in the corresponding config file's `$metaFields` property, and therefore not used (usually
+happens if you change `$metaFields` at some point, thus orphaning some data).
 
 **metaValidationRules(string $prefix=null)**
 

--- a/src/Core/Traits/HasMeta.php
+++ b/src/Core/Traits/HasMeta.php
@@ -123,14 +123,13 @@ trait HasMeta
                 ->where('class', static::class)
                 ->where('resource_id', $this->id)
                 ->where('key', $key)
-                ->update(['value' => $value]);
+                ->set(['value' => $value])
+                ->update();
         }
 
         // Insert
         else {
             $result = $model
-                ->where('class', static::class)
-                ->where('resource_id', $this->id)
                 ->insert([
                     'class'       => static::class,
                     'resource_id' => $this->id,

--- a/src/Core/Traits/HasMeta.php
+++ b/src/Core/Traits/HasMeta.php
@@ -116,7 +116,7 @@ trait HasMeta
     {
         $this->hydrateMeta();
 
-        return array_key_exists(strtolower($key), $this->meta);
+        return array_key_exists(strtolower($key), $this->meta ?? []);
     }
 
     /**

--- a/src/Core/Traits/HasMeta.php
+++ b/src/Core/Traits/HasMeta.php
@@ -93,11 +93,26 @@ trait HasMeta
     }
 
     /**
-     * Does the user have this meta information?
+     * Returns  meta info for this entity in simplified key => value form
      *
-     * @return bool
+     * @return array
      */
-    public function hasMeta(string $key)
+    public function allMetaKeyValue()
+    {
+        $meta = $this->allMeta();
+        $data = [];
+
+        foreach ($meta as $key => $value) {
+            $data[$key] = $value->value;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Does the entry have this meta information?
+     */
+    public function hasMeta(string $key): bool
     {
         $this->hydrateMeta();
 
@@ -168,6 +183,26 @@ trait HasMeta
 
         if ($result) {
             unset($this->meta[$key]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Deletes all meta values for an entity, usually on its deletion.
+     *
+     * @return mixed
+     */
+    public function deleteResourceMeta()
+    {
+        // Delete stuff
+        $result = model(MetaModel::class)
+            ->where('class', static::class)
+            ->where('resource_id', $this->id)
+            ->delete();
+
+        if ($result) {
+            unset($this->meta);
         }
 
         return $result;

--- a/src/Core/Traits/HasMeta.php
+++ b/src/Core/Traits/HasMeta.php
@@ -198,10 +198,14 @@ trait HasMeta
             $inserts = [];
             $updates = [];
             $deletes = [];
+            // Keep only these fields
+            $legal = [];
 
             foreach (array_keys($fields) as $field) {
                 $field    = strtolower($field);
                 $existing = array_key_exists($field, $this->meta);
+                // add to keep list
+                $legal[] = $field;
 
                 // Not existing and no value?
                 if (! $existing && ! array_key_exists($field, $post)) {
@@ -236,22 +240,30 @@ trait HasMeta
                     ];
                 }
             }
-
-            $model = model(MetaModel::class);
-            if ($deletes !== []) {
-                $model->whereIn('id', $deletes)->delete();
-            }
-
-            if ($inserts !== []) {
-                $model->insertBatch($inserts);
-            }
-
-            if ($updates !== []) {
-                $model->updateBatch($updates, 'id');
-            }
-
-            $this->hydrateMeta(true);
         }
+
+        // check if meta in db is in keep list, if not, mark for deletion
+        foreach ($this->meta as $key => $value) {
+            if (! in_array($key, $legal, true)) {
+                $deletes[] = $value->id;
+            }
+        }
+
+        $model = model(MetaModel::class);
+
+        if ($deletes !== []) {
+            $model->whereIn('id', $deletes)->delete();
+        }
+
+        if ($inserts !== []) {
+            $model->insertBatch($inserts);
+        }
+
+        if ($updates !== []) {
+            $model->updateBatch($updates, 'id');
+        }
+
+        $this->hydrateMeta(true);
     }
 
     /**

--- a/tests/Users/MetaTest.php
+++ b/tests/Users/MetaTest.php
@@ -71,6 +71,35 @@ final class MetaTest extends TestCase
         $this->user->deleteMeta('abcdefg');
     }
 
+    public function testDeleteResourceMeta()
+    {
+        // Setup
+        $this->user->saveMeta('foo', 'Some great foo here');
+        $this->user->saveMeta('bar', 'Some great bar there');
+        $this->assertTrue($this->user->hasMeta('foo'));
+        $this->assertTrue($this->user->hasMeta('bar'));
+
+        // Teardown
+        $this->user->deleteResourceMeta();
+        $this->assertFalse($this->user->hasMeta('bar'));
+        $this->dontSeeInDatabase('meta_info', [
+            'class'       => User::class,
+            'resource_id' => $this->user->id,
+        ]);
+
+        // Shouldn't crash when meta doesn't exist
+        $this->user->deleteResourceMeta();
+    }
+
+    public function testAllMetaKeyValue()
+    {
+        $this->user->saveMeta('foo', 'First piece of info');
+        $this->user->saveMeta('bar', 'Some other piece of info');
+        $result = $this->user->allMetaKeyValue();
+
+        $this->assertSame($result['bar'], 'Some other piece of info');
+    }
+
     public function testSyncMeta()
     {
         $this->assertFalse($this->user->hasMeta('foo'));

--- a/tests/Users/MetaTest.php
+++ b/tests/Users/MetaTest.php
@@ -97,7 +97,7 @@ final class MetaTest extends TestCase
         $this->user->saveMeta('bar', 'Some other piece of info');
         $result = $this->user->allMetaKeyValue();
 
-        $this->assertSame($result['bar'], 'Some other piece of info');
+        $this->assertSame('Some other piece of info', $result['bar']);
     }
 
     public function testSyncMeta()


### PR DESCRIPTION
- fix syncMeta() (was performing sync before cycling through all metaFields, which resulted in duplicate data)
- syncMeta() now deletes orphaned data
- fix saveMeta() (was not updating properly)
- add new methods allMetaKeyValud() and deleteResourceMeta()
- update docs accordingly