### PR TITLE
Prevent unnecessary queries related to widgets

### DIFF
--- a/src/Groups/Module.php
+++ b/src/Groups/Module.php
@@ -38,20 +38,22 @@ class Module extends BaseModule
 
         // Settings widgets stats on dashboard
         $widgets   = service('widgets');
-        $groups    = setting('AuthGroups.groups');
         $statsItem = new StatsItem([
             'bgColor' => 'bg-teal',
             'title'   => 'User Groups',
-            'value'   => count($groups),
+            'value'   => count(setting('AuthGroups.groups')),
+            'id'      => 'userGroups643',
             'url'     => ADMIN_AREA . '/settings/groups',
             'faIcon'  => 'fa fa-users',
         ]);
+        // alternative way of retrieving group number (groups "in use"):
+        // $statsItem->addValueByFreeQuery('SELECT COUNT(DISTINCT "group") AS groups FROM auth_groups_users;');
         $widgets->widget('stats')->collection('stats')->addItem($statsItem);
 
-        // Chart Section Begin
         $statsItem = new ChartsItem([
             'title'    => 'User classification by group',
             'type'     => 'line',
+            'id'       => 'usersByGroupLine123',
             'cssClass' => 'col-6',
         ]);
         $statsItem->addDataset('auth_groups_users', 'group', 'user_id');
@@ -60,6 +62,7 @@ class Module extends BaseModule
         $statsItem1 = new ChartsItem([
             'title'    => 'User classification by group',
             'type'     => 'bar',
+            'id'       => 'usersByGroupBar345',
             'cssClass' => 'col-6',
         ]);
         $statsItem1->addDataset('auth_groups_users', 'group', 'user_id');
@@ -68,6 +71,7 @@ class Module extends BaseModule
         $statsItem2 = new ChartsItem([
             'title'    => 'User classification by group',
             'type'     => 'doughnut',
+            'id'       => 'usersByGroupDou654',
             'cssClass' => 'col-3',
         ]);
         $statsItem2->addDataset('auth_groups_users', 'group', 'user_id');
@@ -76,6 +80,7 @@ class Module extends BaseModule
         $statsItem3 = new ChartsItem([
             'title'    => 'User classification by group',
             'type'     => 'pie',
+            'id'       => 'usersByGroupPie223',
             'cssClass' => 'col-3',
         ]);
         $statsItem3->addDataset('auth_groups_users', 'group', 'user_id');
@@ -84,6 +89,7 @@ class Module extends BaseModule
         $statsItem4 = new ChartsItem([
             'title'    => 'User classification by group',
             'type'     => 'polarArea',
+            'id'       => 'usersByGroupPiePolar645',
             'cssClass' => 'col-3',
         ]);
         $statsItem4->addDataset('auth_groups_users', 'group', 'user_id');

--- a/src/Users/Module.php
+++ b/src/Users/Module.php
@@ -13,6 +13,9 @@ namespace Bonfire\Users;
 
 use Bonfire\Core\BaseModule;
 use Bonfire\Menus\MenuItem;
+use Bonfire\Users\Models\UserModel;
+use Bonfire\Widgets\Types\Stats\StatsItem;
+use CodeIgniter\View\Table;
 
 class Module extends BaseModule
 {
@@ -39,5 +42,65 @@ class Module extends BaseModule
             'permission'      => 'users.settings',
         ]);
         $sidebar->menu('sidebar')->collection('settings')->addItem($item);
+
+        // Settings widgets stats on dashboard
+        $widgets   = service('widgets');
+        $statsItem = new StatsItem([
+            'bgColor' => 'bg-danger',
+            'title'   => 'Users in Recycler',
+            // assigning param directly possible, but it always executes the query, even if not on dashboard or the stats item not enabled, not optimal
+            // 'value'   => (new UserModel())->onlyDeleted()->countAllResults(),
+            'id'     => 'usersInRecycler693',
+            'url'    => ADMIN_AREA . '/tools/recycler?r=users',
+            'faIcon' => 'fa fa-users',
+        ]);
+        // better way of retrieving deleted users, executes only when widget is displayed:
+        $statsItem->addValue('users', 'deleted_at IS NOT NULL');
+        // or, the following can be used with more complicated queries:
+        // $statsItem->addValueByFreeQuery('SELECT COUNT(*) AS count FROM users WHERE deleted_at IS NOT NULL;');
+        $widgets->widget('stats')->collection('stats')->addItem($statsItem);
+
+        $widgets    = service('widgets');
+        $statsItem1 = new StatsItem([
+            'bgColor' => 'bg-purple',
+            'title'   => 'Users by Group',
+            'id'      => 'usersExpTable693',
+            'value'   => $this->buildTableUsersByGroup('usersExpTable693'),
+            'url'     => ADMIN_AREA . '/users',
+            'faIcon'  => 'fa fa-users',
+        ]);
+        $widgets->widget('stats')->collection('stats')->addItem($statsItem1);
+    }
+
+    /**
+     * Build the table for the Users by Group stats item to be displayed within widget.
+     *
+     * @param string $statsId - id of the stats item
+     */
+    private function buildTableUsersByGroup($statsId): string
+    {
+        // Check if we are on Dashboard page and the chart is enabled, return empty string if not
+        if (current_url() !== config('App')->baseURL . '/' . ADMIN_AREA || setting('Stats.Stats_' . $statsId) !== 'on') {
+            return '';
+        }
+        $users = new UserModel();
+        $users->select('auth_groups_users.group, COUNT(auth_groups_users.user_id) as count');
+        $users->join('auth_groups_users', 'auth_groups_users.user_id = users.id');
+        $users->groupBy('auth_groups_users.group');
+        $users->orderBy('auth_groups_users.group');
+        $users = $users->findAll();
+
+        $table    = new Table();
+        $template = [
+            'table_open' => '<table style="width: 80%; background-color: transparent; color: white;">',
+        ];
+        $table->setTemplate($template);
+        $table->setHeading('Group', 'Count');
+
+        foreach ($users as $user) {
+            $table->addRow($user->group, $user->count);
+        }
+
+        return $table->generate();
     }
 }

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -36,7 +36,7 @@ class User extends ShieldUser
             }
         }
 
-        $idString = strtoupper($idString);
+        $idString = mb_strtoupper($idString);
 
         $idValue = str_split($idString);
         array_walk($idValue, static function (&$char) {

--- a/src/Widgets/Controllers/WidgetsSettingsController.php
+++ b/src/Widgets/Controllers/WidgetsSettingsController.php
@@ -113,7 +113,7 @@ class WidgetsSettingsController extends AdminController
         $manager = service('widgets')->manager();
 
         foreach ($manager as $elem) {
-            setting('Stats.' . $elem['widget'] . '_' . $elem['index'], $this->request->getPost($elem['widget'] . '_' . $elem['index']) ?? false);
+            setting('Stats.' . $elem['widget'] . '_' . $elem['id'], $this->request->getPost($elem['widget'] . '_' . $elem['id']) ?? false);
         }
     }
 
@@ -232,7 +232,7 @@ class WidgetsSettingsController extends AdminController
         $manager = service('widgets')->manager();
 
         foreach ($manager as $elem) {
-            setting()->forget('Stats.' . $elem['widget'] . '_' . $elem['index']);
+            setting()->forget('Stats.' . $elem['widget'] . '_' . $elem['id']);
         }
 
         setting()->forget('Stats.stats_showLink');

--- a/src/Widgets/Manager.php
+++ b/src/Widgets/Manager.php
@@ -61,7 +61,6 @@ class Manager
                     $pos = substr($items[0]::class, $pos + 1);
                 }
                 $pos = str_replace('Item', '', $pos);
-                $i   = 0;
 
                 switch ($pos) {
                     case 'Stats':
@@ -69,21 +68,20 @@ class Manager
                             $results[] = [
                                 'widget' => $pos,
                                 'title'  => $item->title(),
-                                'index'  => $i,
+                                'id'     => $item->id(),
                             ];
-                            $i++;
                         }
                         break;
 
                     case 'Charts':
+                        // dd($items);
                         foreach ($items as $item) {
                             $results[] = [
                                 'widget' => $pos,
                                 'type'   => $item->type(),
                                 'title'  => $item->title(),
-                                'index'  => $i,
+                                'id'     => $item->id(),
                             ];
-                            $i++;
                         }
                         break;
                 }

--- a/src/Widgets/Types/Charts/ChartsCollection.php
+++ b/src/Widgets/Types/Charts/ChartsCollection.php
@@ -41,7 +41,7 @@ class ChartsCollection extends ChartsItem
     }
 
     /**
-     * Adds a single item to the menu.
+     * Adds a single item to collection.
      */
     public function addItem(ChartsItem $item): ChartsCollection
     {

--- a/src/Widgets/Types/Charts/ChartsItem.php
+++ b/src/Widgets/Types/Charts/ChartsItem.php
@@ -128,7 +128,8 @@ class ChartsItem implements Item
 
     public function title(): ?string
     {
-        return mb_strtoupper((string) $this->title);
+        // Outputing null seems to be demanded by the tests: chartCollectionTest::testTitles()
+        return $this->title ? mb_strtoupper($this->title): null;
     }
 
     public function setTitle(?string $title): ChartsItem

--- a/src/Widgets/Types/Charts/ChartsItem.php
+++ b/src/Widgets/Types/Charts/ChartsItem.php
@@ -129,7 +129,7 @@ class ChartsItem implements Item
     public function title(): ?string
     {
         // Outputing null seems to be demanded by the tests: chartCollectionTest::testTitles()
-        return $this->title ? mb_strtoupper($this->title): null;
+        return $this->title ? mb_strtoupper($this->title) : null;
     }
 
     public function setTitle(?string $title): ChartsItem

--- a/src/Widgets/Types/Charts/ChartsItem.php
+++ b/src/Widgets/Types/Charts/ChartsItem.php
@@ -72,6 +72,13 @@ class ChartsItem implements Item
     protected $title;
 
     /**
+     * Unique identifier for the widget, used for storage in settings.
+     *
+     * @var string
+     */
+    protected $id;
+
+    /**
      * @var array|string|null
      */
     protected $data;
@@ -96,6 +103,11 @@ class ChartsItem implements Item
      */
     protected $chartName;
 
+    /**
+     * @var bool
+     */
+    protected $dashboardRoute = false;
+
     public function __construct(?array $data = null)
     {
         if (! is_array($data)) {
@@ -109,16 +121,31 @@ class ChartsItem implements Item
             }
         }
         $this->setChartName('');
+
+        // true if we are on Dashboard page
+        $this->dashboardRoute = current_url() === config('App')->baseURL . '/' . ADMIN_AREA;
     }
 
     public function title(): ?string
     {
-        return $this->title;
+        return mb_strtoupper((string) $this->title);
     }
 
     public function setTitle(?string $title): ChartsItem
     {
         $this->title = $title;
+
+        return $this;
+    }
+
+    public function id(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setId(?string $id): ChartsItem
+    {
+        $this->id = $id;
 
         return $this;
     }
@@ -266,6 +293,14 @@ class ChartsItem implements Item
 
     public function addDataset(string $tableName, string $groupField, string $countField, string $selectMode = 'count'): ChartsItem
     {
+        // Check if we are on Dashboard page and the chart is enabled, only proceed if both true
+        if (
+            current_url() !== config('App')->baseURL . '/' . ADMIN_AREA
+            || setting('Stats.Charts_' . $this->id) !== 'on'
+        ) {
+            return $this;
+        }
+
         // Chart Section Begin
         $groupsData = db_connect()->table($tableName)
             ->select($groupField);

--- a/src/Widgets/Types/Stats/StatsCollection.php
+++ b/src/Widgets/Types/Stats/StatsCollection.php
@@ -44,7 +44,7 @@ class StatsCollection extends StatsItem
     }
 
     /**
-     * Adds a single item to the menu.
+     * Adds a single item to collection.
      */
     public function addItem(StatsItem $item): StatsCollection
     {

--- a/src/Widgets/Types/Stats/StatsItem.php
+++ b/src/Widgets/Types/Stats/StatsItem.php
@@ -18,6 +18,7 @@ use Bonfire\Widgets\Interfaces\Item;
  *
  * @property string $bgColor
  * @property string $faIcon
+ * @property string $id
  * @property string $title
  * @property string $url
  * @property string $value
@@ -28,6 +29,13 @@ class StatsItem implements Item
      * @var string|null
      */
     protected $title;
+
+    /**
+     * Unique identifier for the widget, used for storage in settings.
+     *
+     * @var string
+     */
+    protected $id;
 
     /**
      * @var string|null
@@ -70,6 +78,11 @@ class StatsItem implements Item
      */
     protected $bgColor;
 
+    /**
+     * @var bool
+     */
+    protected $dashboardRoute = false;
+
     public function __construct(?array $data = null)
     {
         if (! is_array($data)) {
@@ -82,11 +95,21 @@ class StatsItem implements Item
                 $this->{$method}($value);
             }
         }
+
+        // true if we are on Dashboard page
+        $this->dashboardRoute = current_url() === config('App')->baseURL . '/' . ADMIN_AREA;
     }
 
     public function setTitle(?string $title): StatsItem
     {
         $this->title = $title;
+
+        return $this;
+    }
+
+    public function setId(?string $id): StatsItem
+    {
+        $this->id = $id;
 
         return $this;
     }
@@ -152,7 +175,12 @@ class StatsItem implements Item
 
     public function title(): ?string
     {
-        return strtoupper($this->title);
+        return mb_strtoupper((string) $this->title);
+    }
+
+    public function id(): ?string
+    {
+        return $this->id;
     }
 
     public function value(): ?string
@@ -173,5 +201,62 @@ class StatsItem implements Item
     public function bgColor(): ?string
     {
         return $this->bgColor;
+    }
+
+    public function addValue(string $tableName, ?string $whereString = null, string $selectMode = 'count'): StatsItem
+    {
+        // Check if we are on Dashboard page and the chart is enabled
+        if (! $this->dashboardRoute || setting('Stats.Stats_' . $this->id) !== 'on') {
+            return $this;
+        }
+
+        // Chart Section Begin
+        $query = db_connect()->table($tableName);
+
+        if ($whereString) {
+            $query->where($whereString);
+        }
+
+        $query = match ($selectMode) {
+            'count' => $query->countAllResults(),
+            'avg'   => $query->selectAvg('value')->get()->getRow()->value,
+            'max'   => $query->selectMax('value')->get()->getRow()->value,
+            'min'   => $query->selectMin('value')->get()->getRow()->value,
+            'sum'   => $query->selectSum('value')->get()->getRow()->value,
+            default => $query->countAllResults(),
+        };
+
+        // Check if the result is a float and format accordingly
+        if (is_float($query)) {
+            // todo: format the value dynamically based on locale
+            $this->setValue(number_format($query, 2, '.', ''));
+        } else {
+            $this->setValue((string) $query);
+        }
+
+        return $this;
+    }
+
+    public function addValueByFreeQuery(string $query): StatsItem
+    {
+        // Check if we are on Dashboard page and the chart is enabled
+        if (! $this->dashboardRoute || setting('Stats.Stats_' . $this->id) !== 'on') {
+            return $this;
+        }
+
+        // Execute the query
+        $result = db_connect()->query($query)->getRow();
+
+        // Assuming the query returns a single value in the first column
+        $value = reset($result);
+
+        // Check if the result is a float and format accordingly
+        if (is_float($value)) {
+            $this->setValue(number_format($value, 2, '.', ''));
+        } else {
+            $this->setValue((string) $value);
+        }
+
+        return $this;
     }
 }

--- a/src/Widgets/Types/Stats/StatsItem.php
+++ b/src/Widgets/Types/Stats/StatsItem.php
@@ -212,7 +212,7 @@ class StatsItem implements Item
 
         // Chart Section Begin
         $query = db_connect()->table($tableName);
-
+        $query->where('deleted_at', null);
         if ($whereString) {
             $query->where($whereString);
         }

--- a/src/Widgets/Views/Cells/charts.php
+++ b/src/Widgets/Views/Cells/charts.php
@@ -9,7 +9,7 @@
             );
 		    ?>
 
-			<?php if (setting('Stats.' . $_widgets[$index]['widget'] . '_' . $index)) : ?>
+			<?php if (setting('Stats.' . $_widgets[$index]['widget'] . '_' . $_widgets[$index]['id'])) : ?>
                 <div class="<?= $widget->cssClass() ?>">
                     <canvas id="<?= $widget->chartName() ?>" class="chart-border"></canvas>
                 </div>

--- a/src/Widgets/Views/Cells/scripts.php
+++ b/src/Widgets/Views/Cells/scripts.php
@@ -6,7 +6,7 @@
                 array_filter($manager, static fn ($k) => $k['widget'] === 'Charts', ARRAY_FILTER_USE_BOTH)
             );
         ?>
-        <?php if (setting('Stats.' . $_widgets[$index]['widget'] . '_' . $index)) : ?>
+        <?php if (setting('Stats.' . $_widgets[$index]['widget'] . '_' . $_widgets[$index]['id'])) : ?>
             <?= $widget->getScript(); ?>
         <?php endif?>
 

--- a/src/Widgets/Views/Cells/stats.php
+++ b/src/Widgets/Views/Cells/stats.php
@@ -6,7 +6,7 @@
             $_widgets = array_filter($manager, static fn ($k) => $k['widget'] === 'Stats', ARRAY_FILTER_USE_BOTH);
 		    ?>
 
-			<?php if (setting('Stats.' . $_widgets[$index]['widget'] . '_' . $_widgets[$index]['index'])) : ?>
+			<?php if (setting('Stats.' . $_widgets[$index]['widget'] . '_' . $_widgets[$index]['id'])) : ?>
                 <div class="col-3">
                     <div class="widget-stats <?= $widget->bgColor() ?>">
                         <div class="widget-stats-icon"><i class="<?= $widget->faIcon() ?>"></i></div>

--- a/src/Widgets/Views/settings.php
+++ b/src/Widgets/Views/settings.php
@@ -13,15 +13,15 @@
 <x-admin-box>
 
     <form action="<?= site_url(ADMIN_AREA . '/settings/widgets') ?>" method="post">
-		<?= csrf_field() ?>
+        <?= csrf_field() ?>
         <fieldset class="first">
 
             <legend><i class="fas fa-object-group"></i> Widgets Settings</legend>
 
             <p>In this section you can manage widgets on the dashboard.</p>
-            <br/>
+            <br>
 
-			<?php foreach ($manager as $elem): ?>
+            <?php foreach ($manager as $elem): ?>
 
                 <div class="form-check form-switch mt-6 mb-3">
                     <input class="form-check-input" type="checkbox" name="<?= $elem['widget'] ?>_<?= $elem['id'] ?>" role="switch" id="<?= $elem['widget'] ?>_<?= $elem['id'] ?>"
@@ -30,19 +30,19 @@
                     <label class="form-check-label" for="<?= $elem['widget'] ?>_<?= $elem['id'] ?>">Enable <?= rtrim((string) $elem['widget'], 's') ?> <?= $elem['type'] ?? '' ?> widget "<?= $elem['title'] ?>"</label>
                 </div>
 
-			<?php endforeach; ?>
+            <?php endforeach; ?>
         </fieldset>
-        <x-button-container>
+        <div class="text-end px-0 px-md-5">
             <x-button>Save Widget Settings</x-button>
-        </x-button-container>
+        </div>
     </form>
 
-    <form action="<?= site_url(ADMIN_AREA . '/settings/widgetsReset') ?>" method="post">
-		<?= csrf_field() ?>
-        <x-button-container>
+    <x-button-container>
+        <form action="<?= site_url(ADMIN_AREA . '/settings/widgetsReset') ?>" method="post">
+            <?= csrf_field() ?>
             <x-button>Reset all settings of all widgets to their default values</x-button>
-        </x-button-container>
-    </form>
+        </form>
+    </x-button-container>
 </x-admin-box>
 <?php $this->endSection() ?>
 

--- a/src/Widgets/Views/settings.php
+++ b/src/Widgets/Views/settings.php
@@ -24,10 +24,10 @@
 			<?php foreach ($manager as $elem): ?>
 
                 <div class="form-check form-switch mt-6 mb-3">
-                    <input class="form-check-input" type="checkbox" name="<?= $elem['widget'] ?>_<?= $elem['index'] ?>" role="switch" id="<?= $elem['widget'] ?>_<?= $elem['index'] ?>"
-						<?php if (setting('Stats.' . $elem['widget'] . '_' . $elem['index'])) : ?> checked <?php endif ?>
+                    <input class="form-check-input" type="checkbox" name="<?= $elem['widget'] ?>_<?= $elem['id'] ?>" role="switch" id="<?= $elem['widget'] ?>_<?= $elem['id'] ?>"
+                        <?php if (setting('Stats.' . $elem['widget'] . '_' . $elem['id'])) : ?> checked <?php endif ?>
                     >
-                    <label class="form-check-label" for="<?= $elem['widget'] ?>_<?= $elem['index'] ?>">Enable <?= rtrim((string) $elem['widget'], 's') ?> <?= $elem['type'] ?? '' ?> widget "<?= $elem['title'] ?>"</label>
+                    <label class="form-check-label" for="<?= $elem['widget'] ?>_<?= $elem['id'] ?>">Enable <?= rtrim((string) $elem['widget'], 's') ?> <?= $elem['type'] ?? '' ?> widget "<?= $elem['title'] ?>"</label>
                 </div>
 
 			<?php endforeach; ?>

--- a/tests/Widgets/ChartsCollectionTest.php
+++ b/tests/Widgets/ChartsCollectionTest.php
@@ -28,7 +28,7 @@ final class ChartsCollectionTest extends TestCase
             'cssClass' => 'col-3',
         ]);
 
-        $this->assertSame('Item A', $item->title());
+        $this->assertSame('ITEM A', $item->title());
         $this->assertSame('line', $item->type());
         $this->assertSame('col-3', $item->cssClass());
     }
@@ -39,11 +39,11 @@ final class ChartsCollectionTest extends TestCase
         $this->assertNull($collection->title());
 
         $collection = new ChartsCollection(['title' => 'Foo']);
-        $this->assertSame('Foo', $collection->title());
+        $this->assertSame('FOO', $collection->title());
 
         $collection = new ChartsCollection();
         $collection->setTitle('Foo');
-        $this->assertSame('Foo', $collection->title());
+        $this->assertSame('FOO', $collection->title());
     }
 
     public function testWithItem()
@@ -58,15 +58,15 @@ final class ChartsCollectionTest extends TestCase
         $items = $chart_collection->items();
 
         $this->assertCount(2, $items);
-        $this->assertSame('Item 1', $items[0]->title());
-        $this->assertSame('Item 2', $items[1]->title());
+        $this->assertSame('ITEM 1', $items[0]->title());
+        $this->assertSame('ITEM 2', $items[1]->title());
 
-        $chart_collection->removeItem('Item 1');
+        $chart_collection->removeItem('ITEM 1');
 
         $items = $chart_collection->items();
 
         $this->assertCount(1, $items);
-        $this->assertSame('Item 2', $items[0]->title());
+        $this->assertSame('ITEM 2', $items[0]->title());
 
         $chart_collection->removeAllItems();
 
@@ -85,7 +85,7 @@ final class ChartsCollectionTest extends TestCase
         $items = $chart_collection->items();
 
         $this->assertCount(2, $items);
-        $this->assertSame('Item 1', $items[0]->title());
-        $this->assertSame('Item 2', $items[1]->title());
+        $this->assertSame('ITEM 1', $items[0]->title());
+        $this->assertSame('ITEM 2', $items[1]->title());
     }
 }

--- a/tests/Widgets/ChartsItemTest.php
+++ b/tests/Widgets/ChartsItemTest.php
@@ -26,7 +26,7 @@ final class ChartsItemTest extends TestCase
             ->setType('line')
             ->setCssclass('col-3');
 
-        $this->assertSame('Item A', $item->title());
+        $this->assertSame('ITEM A', $item->title());
         $this->assertSame('line', $item->type());
         $this->assertSame('col-3', $item->cssClass());
     }
@@ -39,7 +39,7 @@ final class ChartsItemTest extends TestCase
             'cssClass' => 'col-3',
         ]);
 
-        $this->assertSame('Item A', $item->title());
+        $this->assertSame('ITEM A', $item->title());
         $this->assertSame('line', $item->type());
         $this->assertSame('col-3', $item->cssClass());
     }

--- a/tests/Widgets/ChartsTest.php
+++ b/tests/Widgets/ChartsTest.php
@@ -33,8 +33,8 @@ final class ChartsTest extends TestCase
         $items = $widget->items();
 
         $this->assertCount(2, $items);
-        $this->assertSame('Item 1', $items[0]->title());
-        $this->assertSame('Item 2', $items[1]->title());
+        $this->assertSame('ITEM 1', $items[0]->title());
+        $this->assertSame('ITEM 2', $items[1]->title());
     }
 
     public function testCreateCollection()


### PR DESCRIPTION
This would fix issue #524 - at present every single query to gather data is run for every widget independently on whether the widget is displayed, on every page load.

These changes ensure that the queries related to widgets:
  - are being run only when the dashboard is displayed
  - only the queries of the enabled widgets are run

This is what is new:
  - check if the route was that of the dashboard page
  - hardcode unique ids for each widget
  - check in the Module file for these and only run the addDataset() method is the above conditions are met. 
  - create an addValue() method for StatsItem where previously the value to be displayed was acquired through the constructor (though leaving the old method as a possibility)
  - I also added some charts and stats widgets to the Users module, that showcase the possibilities.

The initial implementation did not look elegant to me. However, I have improved it to a point where I rather like it. 

Since this is a significant change (also introducing breaking changes to user-added modules), I  requested a review from @lonnieezell. If approved, I will also document the changes appropriately.