### PR TITLE
Fix problem with HasMeta

### DIFF
--- a/src/Core/Traits/HasMeta.php
+++ b/src/Core/Traits/HasMeta.php
@@ -224,16 +224,16 @@ trait HasMeta
             return;
         }
 
+        $inserts = [];
+        $updates = [];
+        $deletes = [];
+        // Keep only these fields = delete orphaned
+        $legal = [];
+
         foreach ($metaInfo as $fields) {
             if (! is_array($fields) || $fields === []) {
                 continue;
             }
-
-            $inserts = [];
-            $updates = [];
-            $deletes = [];
-            // Keep only these fields
-            $legal = [];
 
             foreach (array_keys($fields) as $field) {
                 $field    = strtolower($field);

--- a/tests/Groups/GroupsTest.php
+++ b/tests/Groups/GroupsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Groups;
 
 use Bonfire\Users\User;
 use CodeIgniter\Shield\Authorization\Groups;
+use CodeIgniter\Shield\Entities\Group;
 use Tests\Support\TestCase;
 
 /**
@@ -70,6 +71,7 @@ final class GroupsTest extends TestCase
     {
         $groups = new Groups();
         $group  = $groups->info('admin');
+        $this->assertInstanceof(Group::class, $group);
 
         $this->assertTrue($group->can('beta.access'));
 
@@ -85,9 +87,11 @@ final class GroupsTest extends TestCase
 
         // Page title
         $result->assertRedirect();
+        $this->assertInstanceof(Group::class, $group);
 
         // Refresh the group
         $group = $groups->info('admin');
+        $this->assertInstanceof(Group::class, $group);
 
         $this->assertFalse($group->can('beta.access'));
     }


### PR DESCRIPTION
Move the arrays collecting info on meta info to update/delete/insert outside of the loop so they are not overwritten when more than one meta fieldset is present.