### PR TITLE
Publish alerts config file on install

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -16,6 +16,7 @@ use Bonfire\Auth\Config\Auth;
 use Bonfire\Auth\Config\AuthGroups;
 use Bonfire\Auth\Config\AuthToken;
 use Bonfire\Commands\Install\Publisher;
+use Bonfire\Config\Alerts;
 use Bonfire\Config\Bonfire;
 use Bonfire\Config\Site;
 use Bonfire\Config\Themes;
@@ -85,6 +86,7 @@ class Install extends BaseCommand
     ];
 
     private array $configFiles = [
+        Alerts::class,
         Assets::class,
         Auth::class,
         AuthGroups::class,

--- a/src/Commands/Install/Publisher.php
+++ b/src/Commands/Install/Publisher.php
@@ -69,6 +69,8 @@ class Publisher
             'use CodeIgniter\Shield\Config\Auth as ShieldAuth;'             => 'use Bonfire\Auth\Config\Auth as BonfireAuth;',
             'use CodeIgniter\Shield\Config\AuthGroups as ShieldAuthGroups;' => 'use Bonfire\Auth\Config\AuthGroups as BonfireAuthGroups;',
             'use CodeIgniter\Shield\Config\AuthToken as ShieldAuthToken;'   => 'use Bonfire\Auth\Config\AuthToken as BonfireAuthToken;',
+            'use Tatter\Alerts\Config\Alerts as AlertsConfig;'              => 'use Bonfire\Config\Alerts as BonfireAlerts;',
+            'class Alerts extends AlertsConfig'                             => 'class Alerts extends BonfireAlerts',
             "class {$rawClassName} extends Shield{$rawClassName}"           => "class {$rawClassName} extends Bonfire{$rawClassName}",
         ];
 


### PR DESCRIPTION
For some reason Alerts file was not published on install, so Bonfire's alerts with icons were not used. 

This PR fixes the issue.