### PR TITLE
Email settings (port and timeout) saved as strings in database

### DIFF
--- a/src/Email/Controllers/EmailSettingsController.php
+++ b/src/Email/Controllers/EmailSettingsController.php
@@ -65,11 +65,11 @@ class EmailSettingsController extends AdminController
         setting('Email.protocol', $this->request->getPost('protocol'));
         setting('Email.mailPath', $this->request->getPost('mailPath'));
         setting('Email.SMTPHost', $this->request->getPost('SMTPHost'));
-        setting('Email.SMTPPort', $port);
+        setting('Email.SMTPPort', intval($port));
         setting('Email.SMTPUser', $this->request->getPost('SMTPUser'));
         setting('Email.SMTPPass', $this->request->getPost('SMTPPass'));
         setting('Email.SMTPCrypto', $this->request->getPost('SMTPCrypto'));
-        setting('Email.SMTPTimeout', $this->request->getPost('SMTPTimeout'));
+        setting('Email.SMTPTimeout', floatval($this->request->getPost('SMTPTimeout')));
         setting('Email.SMTPKeepAlive', $this->request->getPost('SMTPKeepAlive'));
 
         alert('success', 'The settings have been saved.');

--- a/src/Email/Views/email_settings.php
+++ b/src/Email/Views/email_settings.php
@@ -91,10 +91,10 @@
                             <div class="form-group col-12 col-sm-3">
                                 <label for="SMTPPort" class="form-label">Port</label>
                                 <select name="SMTPPort" class="form-select">
-                                    <option value="25" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === '25') : ?> selected <?php endif?>>25</option>
-                                    <option value="587" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === '587') : ?> selected <?php endif?>>587</option>
-                                    <option value="465" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === '465') : ?> selected <?php endif?>>465</option>
-                                    <option value="2525" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === '2525') : ?> selected <?php endif?>>2525</option>
+                                    <option value="25" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === 25) : ?> selected <?php endif?>>25</option>
+                                    <option value="587" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === 587) : ?> selected <?php endif?>>587</option>
+                                    <option value="465" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === 465) : ?> selected <?php endif?>>465</option>
+                                    <option value="2525" @click="open = false" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === 2525) : ?> selected <?php endif?>>2525</option>
                                     <option value="other" @click="open = ! open" <?php if (old('SMTPPort', setting('Email.SMTPPort')) === 'other') : ?> selected <?php endif?>>other</option>
                                 </select>
                                 <?php if (has_error('SMTPPort')) : ?>


### PR DESCRIPTION
Changed `EmailSettingsController.php` to use intval() and floatval() when saving to database - changed `email_settings.php` to interpret integers instead of strings when displaying port options

Fixes: https://github.com/lonnieezell/Bonfire2/issues/578