### PR TITLE
Fix: enable attribute parsing for self-closing components

### DIFF
--- a/src/View/ComponentRenderer.php
+++ b/src/View/ComponentRenderer.php
@@ -96,7 +96,7 @@ class ComponentRenderer
             $component  = $this->factory($match['name'], $view);
 
             return $component instanceof Component
-                ? $component->withView($view)->render()
+                ? $component->withView($view)->withData($attributes)->render()
                 : $this->renderView($view, $attributes);
         }, $output);
     }


### PR DESCRIPTION
For the self-closing components the attributes passed were never applied. Now it is fixed.